### PR TITLE
fix: tighten profile duplicate detection

### DIFF
--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -21,6 +21,24 @@ function parseJWT(token: string): any {
   }
 }
 
+function getDefaultOrganization(authPayload: any): {
+  id?: string
+  title?: string
+} {
+  const organizations = authPayload?.['https://api.openai.com/auth']?.organizations
+  if (!Array.isArray(organizations)) {
+    return {}
+  }
+
+  const selected =
+    organizations.find((org: any) => org?.is_default) || organizations[0]
+
+  return {
+    id: typeof selected?.id === 'string' ? selected.id : undefined,
+    title: typeof selected?.title === 'string' ? selected.title : undefined,
+  }
+}
+
 /**
  * Resolve default Codex auth file path.
  */
@@ -46,12 +64,15 @@ export async function loadAuthDataFromFile(
 
     // Parse ID token to get user info
     const idTokenPayload = parseJWT(authJson.tokens.id_token)
+    const defaultOrganization = getDefaultOrganization(idTokenPayload)
 
     return {
       idToken: authJson.tokens.id_token,
       accessToken: authJson.tokens.access_token,
       refreshToken: authJson.tokens.refresh_token,
       accountId: authJson.tokens.account_id,
+      defaultOrganizationId: defaultOrganization.id,
+      defaultOrganizationTitle: defaultOrganization.title,
       email: idTokenPayload.email || 'Unknown',
       planType:
         idTokenPayload['https://api.openai.com/auth']?.chatgpt_plan_type ||

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -45,15 +45,32 @@ export class ProfileManager {
   }
 
   private matchesAuth(profile: ProfileSummary, authData: AuthData): boolean {
-    if (authData.accountId && profile.accountId && authData.accountId === profile.accountId) {
-      return true
-    }
-
     const pe = this.normalizeEmail(profile.email)
     const ae = this.normalizeEmail(authData.email)
-    if (!pe || !ae) return false
-    if (pe === 'unknown' || ae === 'unknown') return false
-    return pe === ae
+    const hasComparableEmail =
+      Boolean(pe) &&
+      Boolean(ae) &&
+      pe !== 'unknown' &&
+      ae !== 'unknown'
+    const hasComparableAccountId =
+      Boolean(authData.accountId) && Boolean(profile.accountId)
+
+    // When both identifiers are present, require both to match.
+    // Team accounts can share accountId across different users, and the same
+    // email can legitimately have multiple plans/accounts.
+    if (hasComparableEmail && hasComparableAccountId) {
+      return pe === ae && authData.accountId === profile.accountId
+    }
+
+    if (hasComparableEmail) {
+      return pe === ae
+    }
+
+    if (hasComparableAccountId) {
+      return authData.accountId === profile.accountId
+    }
+
+    return false
   }
 
   private getStorageDir(): string {

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -44,9 +44,15 @@ export class ProfileManager {
     return String(email || '').trim().toLowerCase()
   }
 
+  private normalizeOrganizationId(id: string | undefined): string {
+    return String(id || '').trim()
+  }
+
   private matchesAuth(profile: ProfileSummary, authData: AuthData): boolean {
     const pe = this.normalizeEmail(profile.email)
     const ae = this.normalizeEmail(authData.email)
+    const po = this.normalizeOrganizationId(profile.defaultOrganizationId)
+    const ao = this.normalizeOrganizationId(authData.defaultOrganizationId)
     const hasComparableEmail =
       Boolean(pe) &&
       Boolean(ae) &&
@@ -54,12 +60,38 @@ export class ProfileManager {
       ae !== 'unknown'
     const hasComparableAccountId =
       Boolean(authData.accountId) && Boolean(profile.accountId)
+    const hasComparableOrganizationId = Boolean(po) && Boolean(ao)
 
-    // When both identifiers are present, require both to match.
+    // When all identity signals are present, require all of them to match.
+    // This allows importing multiple workspaces under the same user/account
+    // while still avoiding false-positive duplicate detection.
+    if (
+      hasComparableEmail &&
+      hasComparableAccountId &&
+      hasComparableOrganizationId
+    ) {
+      return (
+        pe === ae &&
+        authData.accountId === profile.accountId &&
+        ao === po
+      )
+    }
+
+    // If we know only email+account, use those two together.
     // Team accounts can share accountId across different users, and the same
     // email can legitimately have multiple plans/accounts.
     if (hasComparableEmail && hasComparableAccountId) {
       return pe === ae && authData.accountId === profile.accountId
+    }
+
+    // If only account+workspace are known, use those together.
+    if (hasComparableAccountId && hasComparableOrganizationId) {
+      return authData.accountId === profile.accountId && ao === po
+    }
+
+    // If only email+workspace are known, use those together.
+    if (hasComparableEmail && hasComparableOrganizationId) {
+      return pe === ae && ao === po
     }
 
     if (hasComparableEmail) {
@@ -240,6 +272,8 @@ export class ProfileManager {
       email: authData.email,
       planType: authData.planType,
       accountId: authData.accountId,
+      defaultOrganizationId: authData.defaultOrganizationId,
+      defaultOrganizationTitle: authData.defaultOrganizationTitle,
       updatedAt: new Date().toISOString(),
     }
     this.writeProfilesFile(file)
@@ -278,6 +312,8 @@ export class ProfileManager {
       email: authData.email,
       planType: authData.planType,
       accountId: authData.accountId,
+      defaultOrganizationId: authData.defaultOrganizationId,
+      defaultOrganizationTitle: authData.defaultOrganizationTitle,
       createdAt: now,
       updatedAt: now,
     }
@@ -344,6 +380,8 @@ export class ProfileManager {
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,
         accountId: tokens.accountId,
+        defaultOrganizationId: profile.defaultOrganizationId,
+        defaultOrganizationTitle: profile.defaultOrganizationTitle,
         email: profile.email,
         planType: profile.planType,
         authJson: tokens.authJson,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export interface AuthData {
     accessToken: string;
     refreshToken: string;
     accountId?: string;
+    defaultOrganizationId?: string;
+    defaultOrganizationTitle?: string;
     email: string;
     planType: string;
     authJson?: Record<string, unknown>;
@@ -14,6 +16,8 @@ export interface ProfileSummary {
     email: string;
     planType: string;
     accountId?: string;
+    defaultOrganizationId?: string;
+    defaultOrganizationTitle?: string;
     createdAt: string;
     updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- require `email`, `account_id`, and the selected default organization/workspace to match when all three identifiers are available
- fall back to narrower identifier pairs only when one of the three signals is missing
- preserve valid multi-profile cases where one email has multiple accounts, multiple workspaces can exist under one account, and Team accounts can share one `account_id` across different users

Closes #1
Closes #3

## Verification
- `npm run compile`
- verified duplicate matching for:
  - same user/account, different workspace -> imports independently
  - same user/account/workspace -> detected as duplicate
  - different user, shared team account -> imports independently
