### PR TITLE
fix: stop creating auth.json backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,12 +98,6 @@
           "type": "boolean",
           "default": false,
           "description": "%configuration.reloadWindowAfterProfileSwitch.description%"
-        },
-        "codexSwitch.maxAuthBackups": {
-          "type": "number",
-          "default": 10,
-          "minimum": 0,
-          "description": "%configuration.maxAuthBackups.description%"
         }
       }
     }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: Aus Datei importieren",
   "command.profile.rename.title": "Codex Switch: Profil umbenennen",
   "command.profile.delete.title": "Codex Switch: Profil loeschen",
-  "configuration.maxAuthBackups.description": "Maximale Anzahl der zu behaltenden auth.json-Backups (0 deaktiviert Backups)",
   "configuration.reloadWindowAfterProfileSwitch.description": "VS Code-Fenster nach erfolgreichem Profilwechsel/-import neu laden, damit die Codex-Erweiterung auth.json erneut einliest"
 }

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: Importar desde archivo",
   "command.profile.rename.title": "Codex Switch: Renombrar perfil",
   "command.profile.delete.title": "Codex Switch: Eliminar perfil",
-  "configuration.maxAuthBackups.description": "Cantidad maxima de copias de seguridad de auth.json a conservar (0 desactiva las copias)",
   "configuration.reloadWindowAfterProfileSwitch.description": "Recargar la ventana de VS Code despues de cambiar/importar un perfil correctamente para que la extension Codex vuelva a leer auth.json"
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: Importer depuis un fichier",
   "command.profile.rename.title": "Codex Switch: Renommer le profil",
   "command.profile.delete.title": "Codex Switch: Supprimer le profil",
-  "configuration.maxAuthBackups.description": "Nombre maximum de sauvegardes auth.json a conserver (0 desactive les sauvegardes)",
   "configuration.reloadWindowAfterProfileSwitch.description": "Recharger la fenetre VS Code apres un changement/import de profil reussi afin que l'extension Codex relise auth.json"
 }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: Importa da file",
   "command.profile.rename.title": "Codex Switch: Rinomina profilo",
   "command.profile.delete.title": "Codex Switch: Elimina profilo",
-  "configuration.maxAuthBackups.description": "Numero massimo di backup di auth.json da conservare (0 disattiva i backup)",
   "configuration.reloadWindowAfterProfileSwitch.description": "Ricarica la finestra di VS Code dopo il cambio/importazione profilo riuscito, cosi l'estensione Codex rilegge auth.json"
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: ファイルからインポート",
   "command.profile.rename.title": "Codex Switch: プロファイル名を変更",
   "command.profile.delete.title": "Codex Switch: プロファイルを削除",
-  "configuration.maxAuthBackups.description": "保持する auth.json バックアップの最大数 (0 でバックアップを無効化)",
   "configuration.reloadWindowAfterProfileSwitch.description": "プロファイルの切り替え/インポート成功後に VS Code ウィンドウを再読み込みして、Codex 拡張機能が auth.json を再読込するようにします"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,7 +5,6 @@
   "configuration.debugLogging.description": "Enable verbose logging (never prints tokens)",
   "configuration.activeProfileScope.description": "Where to store active profile selection",
   "configuration.reloadWindowAfterProfileSwitch.description": "Reload VS Code window after successful profile switch/import so Codex extension re-reads auth.json",
-  "configuration.maxAuthBackups.description": "Maximum number of auth.json backups to keep (0 disables backups)",
   "command.login.title": "Codex Switch: Login Help",
   "command.profile.manage.title": "Codex Switch: Manage Profiles",
   "command.profile.login.title": "Codex Switch: Login (Codex CLI)",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: 파일에서 가져오기",
   "command.profile.rename.title": "Codex Switch: 프로필 이름 변경",
   "command.profile.delete.title": "Codex Switch: 프로필 삭제",
-  "configuration.maxAuthBackups.description": "유지할 auth.json 백업의 최대 개수(0이면 백업 비활성화)",
   "configuration.reloadWindowAfterProfileSwitch.description": "프로필 전환/가져오기에 성공한 후 Codex 확장이 auth.json을 다시 읽도록 VS Code 창을 다시 로드합니다"
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: Importar de arquivo",
   "command.profile.rename.title": "Codex Switch: Renomear perfil",
   "command.profile.delete.title": "Codex Switch: Excluir perfil",
-  "configuration.maxAuthBackups.description": "Numero maximo de backups do auth.json a manter (0 desativa backups)",
   "configuration.reloadWindowAfterProfileSwitch.description": "Recarregar a janela do VS Code apos trocar/importar perfil com sucesso para que a extensao Codex releia o auth.json"
 }

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -5,7 +5,6 @@
   "configuration.debugLogging.description": "Включить подробные логи (токены не выводятся)",
   "configuration.activeProfileScope.description": "Где хранить выбор активного профиля",
   "configuration.reloadWindowAfterProfileSwitch.description": "Перезагружать окно VS Code после успешного переключения/импорта профиля, чтобы расширение Codex перечитало auth.json",
-  "configuration.maxAuthBackups.description": "Максимальное количество бэкапов auth.json (0 отключает бэкапы)",
   "command.login.title": "Codex Switch: Помощь по входу",
   "command.profile.manage.title": "Codex Switch: Управление профилями",
   "command.profile.login.title": "Codex Switch: Войти (Codex CLI)",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: 从文件导入",
   "command.profile.rename.title": "Codex Switch: 重命名配置文件",
   "command.profile.delete.title": "Codex Switch: 删除配置文件",
-  "configuration.maxAuthBackups.description": "保留的 auth.json 备份最大数量（0 表示禁用备份）",
   "configuration.reloadWindowAfterProfileSwitch.description": "在成功切换/导入配置后重新加载 VS Code 窗口，以便 Codex 扩展重新读取 auth.json"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -13,6 +13,5 @@
   "command.profile.addFromFile.title": "Codex Switch: 從檔案匯入",
   "command.profile.rename.title": "Codex Switch: 重新命名設定檔",
   "command.profile.delete.title": "Codex Switch: 刪除設定檔",
-  "configuration.maxAuthBackups.description": "保留的 auth.json 備份最大數量（0 表示停用備份）",
   "configuration.reloadWindowAfterProfileSwitch.description": "在成功切換/匯入設定檔後重新載入 VS Code 視窗，讓 Codex 擴充功能重新讀取 auth.json"
 }

--- a/src/auth/codex-auth-sync.ts
+++ b/src/auth/codex-auth-sync.ts
@@ -2,50 +2,6 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { AuthData } from '../types'
 
-function pad2(n: number): string {
-  return String(n).padStart(2, '0')
-}
-
-function coerceMaxBackups(value: unknown, fallback: number): number {
-  const n = typeof value === 'number' ? value : Number(value)
-  if (!Number.isFinite(n)) return fallback
-  return Math.max(0, Math.floor(n))
-}
-
-function backupSuffix(now: Date): string {
-  // YYYYMMDD-HHMMSS
-  return `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(now.getHours())}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`
-}
-
-function pruneAuthBackups(authPath: string, maxBackups: number) {
-  const dir = path.dirname(authPath)
-  const base = path.basename(authPath)
-  const prefix = `${base}.bak.`
-
-  let names: string[] = []
-  try {
-    names = fs.readdirSync(dir)
-  } catch {
-    return
-  }
-
-  const backups = names
-    .filter((n) => n.startsWith(prefix))
-    // backupSuffix is lexicographically sortable (YYYYMMDD-HHMMSS).
-    .sort((a, b) => b.localeCompare(a))
-
-  for (const name of backups.slice(maxBackups)) {
-    const fp = path.join(dir, name)
-    try {
-      const st = fs.statSync(fp)
-      if (!st.isFile()) continue
-      fs.unlinkSync(fp)
-    } catch {
-      // Best-effort cleanup.
-    }
-  }
-}
-
 export function buildCodexAuthJson(authData: AuthData): string {
   // Preserve the full auth payload when available so other clients that rely on
   // additional metadata (for example token_data/auth status fields) keep working.
@@ -68,30 +24,12 @@ export function buildCodexAuthJson(authData: AuthData): string {
   return `${JSON.stringify(payload, null, 2)}\n`
 }
 
-export function syncCodexAuthFile(
-  authPath: string,
-  authData: AuthData,
-  opts?: { maxBackups?: number },
-) {
+export function syncCodexAuthFile(authPath: string, authData: AuthData) {
   const dir = path.dirname(authPath)
   fs.mkdirSync(dir, { recursive: true })
 
-  const now = new Date()
-  const tmpPath = path.join(dir, `auth.json.tmp.${process.pid}.${now.getTime()}`)
+  const tmpPath = path.join(dir, `auth.json.tmp.${process.pid}.${Date.now()}`)
   const content = buildCodexAuthJson(authData)
-  const maxBackups = coerceMaxBackups(opts?.maxBackups, 10)
-
-  // Backup existing file first.
-  if (maxBackups > 0 && fs.existsSync(authPath)) {
-    const backupPath = `${authPath}.bak.${backupSuffix(now)}`
-    try {
-      fs.copyFileSync(authPath, backupPath)
-    } catch {
-      // Best-effort backup.
-    }
-  }
-
-  pruneAuthBackups(authPath, maxBackups)
 
   fs.writeFileSync(tmpPath, content, { encoding: 'utf8' })
 

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -32,14 +32,6 @@ export class ProfileManager {
 
   private lastSyncedProfileId: string | undefined
 
-  private getMaxAuthBackups(): number {
-    const cfg = vscode.workspace.getConfiguration('codexSwitch')
-    const raw = cfg.get<number>('maxAuthBackups', 10)
-    const n = typeof raw === 'number' ? raw : Number(raw)
-    if (!Number.isFinite(n)) return 10
-    return Math.max(0, Math.floor(n))
-  }
-
   private normalizeEmail(email: string | undefined): string {
     return String(email || '').trim().toLowerCase()
   }
@@ -262,9 +254,7 @@ export class ProfileManager {
     const authData = await this.loadAuthData(profileId)
     if (!authData) return
 
-    syncCodexAuthFile(getDefaultCodexAuthPath(), authData, {
-      maxBackups: this.getMaxAuthBackups(),
-    })
+    syncCodexAuthFile(getDefaultCodexAuthPath(), authData)
     this.lastSyncedProfileId = profileId
   }
 
@@ -419,9 +409,7 @@ export class ProfileManager {
 
     if (profileId && authData) {
       // We already validated tokens above; avoid a second secret read.
-      syncCodexAuthFile(getDefaultCodexAuthPath(), authData, {
-        maxBackups: this.getMaxAuthBackups(),
-      })
+      syncCodexAuthFile(getDefaultCodexAuthPath(), authData)
       this.lastSyncedProfileId = profileId
     }
     return true


### PR DESCRIPTION
## Summary
- stop creating `auth.json.bak.*` files when syncing the active profile
- keep the existing temp-file + replace flow for the actual `auth.json` write
- remove the now-unused backup retention setting from the extension manifest and localized strings

Closes #6

## Why
The backup files store the full auth payload in plaintext, which unnecessarily multiplies token copies on disk.

## Verification
- `npm run compile`
