### PR TITLE
feat: switch profiles directly from tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-switch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-switch",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@types/node": "24.x",
         "@types/vscode": "^1.105.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "publisher": "woozy-masta",
   "scripts": {

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -45,15 +45,32 @@ export class ProfileManager {
   }
 
   private matchesAuth(profile: ProfileSummary, authData: AuthData): boolean {
-    if (authData.accountId && profile.accountId && authData.accountId === profile.accountId) {
-      return true
-    }
-
     const pe = this.normalizeEmail(profile.email)
     const ae = this.normalizeEmail(authData.email)
-    if (!pe || !ae) return false
-    if (pe === 'unknown' || ae === 'unknown') return false
-    return pe === ae
+    const hasComparableEmail =
+      Boolean(pe) &&
+      Boolean(ae) &&
+      pe !== 'unknown' &&
+      ae !== 'unknown'
+    const hasComparableAccountId =
+      Boolean(authData.accountId) && Boolean(profile.accountId)
+
+    // When both identifiers are present, require both to match.
+    // Team accounts can share accountId across different users, and the same
+    // email can legitimately have multiple plans/accounts.
+    if (hasComparableEmail && hasComparableAccountId) {
+      return pe === ae && authData.accountId === profile.accountId
+    }
+
+    if (hasComparableEmail) {
+      return pe === ae
+    }
+
+    if (hasComparableAccountId) {
+      return authData.accountId === profile.accountId
+    }
+
+    return false
   }
 
   private getStorageDir(): string {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { ProfileManager } from '../auth/profile-manager'
 import { getDefaultCodexAuthPath, loadAuthDataFromFile } from '../auth/auth-manager'
-import { bounceStatusBarItem } from '../ui/status-bar'
 
 /**
  * Register all extension commands
@@ -98,7 +97,6 @@ export function registerCommands(
       if (!ok) return
 
       await onAuthChanged()
-      bounceStatusBarItem()
       await maybeReloadWindowAfterProfileSwitch()
     },
   )
@@ -106,11 +104,21 @@ export function registerCommands(
   const toggleLastProfileCommand = vscode.commands.registerCommand(
     'codex-switch.profile.toggleLast',
     async () => {
-      const newId = await profileManager.toggleLastProfileId()
-      if (!newId) {
-        await vscode.commands.executeCommand('codex-switch.profile.switch')
+      const profiles = await profileManager.listProfiles()
+      if (profiles.length === 0) {
+        await vscode.commands.executeCommand('codex-switch.profile.manage')
         return
       }
+
+      const activeId = await profileManager.getActiveProfileId()
+      const currentIndex = profiles.findIndex((p) => p.id === activeId)
+      const nextIndex =
+        currentIndex === -1
+          ? 0
+          : (currentIndex + 1) % profiles.length
+      const ok = await profileManager.setActiveProfileId(profiles[nextIndex].id)
+      if (!ok) return
+
       await onAuthChanged()
       await maybeReloadWindowAfterProfileSwitch()
     },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { ProfileManager } from '../auth/profile-manager'
 import { getDefaultCodexAuthPath, loadAuthDataFromFile } from '../auth/auth-manager'
+import { bounceStatusBarItem } from '../ui/status-bar'
 
 /**
  * Register all extension commands
@@ -97,6 +98,7 @@ export function registerCommands(
       if (!ok) return
 
       await onAuthChanged()
+      bounceStatusBarItem()
       await maybeReloadWindowAfterProfileSwitch()
     },
   )

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -116,7 +116,6 @@ export function registerCommands(
       const existing = await profileManager.findDuplicateProfile(authData)
       if (existing) {
         const replaceLabel = vscode.l10n.t('Replace')
-        const cancelLabel = vscode.l10n.t('Cancel')
         const pick = await vscode.window.showWarningMessage(
           vscode.l10n.t(
             'This account is already saved as profile "{0}". Replace it?',
@@ -124,7 +123,6 @@ export function registerCommands(
           ),
           { modal: true },
           replaceLabel,
-          cancelLabel,
         )
         if (pick !== replaceLabel) return
 
@@ -260,7 +258,6 @@ export function registerCommands(
       const existing = await profileManager.findDuplicateProfile(authData)
       if (existing) {
         const replaceLabel = vscode.l10n.t('Replace')
-        const cancelLabel = vscode.l10n.t('Cancel')
         const pick = await vscode.window.showWarningMessage(
           vscode.l10n.t(
             'This account is already saved as profile "{0}". Replace it?',
@@ -268,7 +265,6 @@ export function registerCommands(
           ),
           { modal: true },
           replaceLabel,
-          cancelLabel,
         )
         if (pick !== replaceLabel) return
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -85,6 +85,22 @@ export function registerCommands(
     },
   )
 
+  const activateProfileCommand = vscode.commands.registerCommand(
+    'codex-switch.profile.activate',
+    async (profileId?: string) => {
+      if (!profileId) {
+        await vscode.commands.executeCommand('codex-switch.profile.switch')
+        return
+      }
+
+      const ok = await profileManager.setActiveProfileId(profileId)
+      if (!ok) return
+
+      await onAuthChanged()
+      await maybeReloadWindowAfterProfileSwitch()
+    },
+  )
+
   const toggleLastProfileCommand = vscode.commands.registerCommand(
     'codex-switch.profile.toggleLast',
     async () => {
@@ -400,6 +416,7 @@ export function registerCommands(
   context.subscriptions.push(loginCommand)
   context.subscriptions.push(loginViaCliCommand)
   context.subscriptions.push(switchProfileCommand)
+  context.subscriptions.push(activateProfileCommand)
   context.subscriptions.push(toggleLastProfileCommand)
   context.subscriptions.push(manageProfilesCommand)
   context.subscriptions.push(addFromCodexAuthFileCommand)

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -44,11 +44,3 @@ export function updateProfileStatus(
 export function getStatusBarItem(): vscode.StatusBarItem {
   return statusBarItem
 }
-
-export function bounceStatusBarItem(): void {
-  if (!statusBarItem) return
-  statusBarItem.hide()
-  setTimeout(() => {
-    statusBarItem.show()
-  }, 10)
-}

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -44,3 +44,11 @@ export function updateProfileStatus(
 export function getStatusBarItem(): vscode.StatusBarItem {
   return statusBarItem
 }
+
+export function bounceStatusBarItem(): void {
+  if (!statusBarItem) return
+  statusBarItem.hide()
+  setTimeout(() => {
+    statusBarItem.show()
+  }, 10)
+}

--- a/src/ui/tooltip-builder.ts
+++ b/src/ui/tooltip-builder.ts
@@ -2,6 +2,10 @@ import * as vscode from 'vscode'
 import { ProfileSummary } from '../types'
 import { escapeMarkdown } from '../utils/markdown'
 
+function buildCommandUri(command: string, args: unknown[]): string {
+  return `command:${command}?${encodeURIComponent(JSON.stringify(args))}`
+}
+
 export function createProfileTooltip(
   activeProfile: ProfileSummary | null,
   profiles: ProfileSummary[],
@@ -12,6 +16,7 @@ export function createProfileTooltip(
   tooltip.isTrusted = {
     enabledCommands: [
       'codex-switch.profile.manage',
+      'codex-switch.profile.activate',
     ],
   }
 
@@ -29,12 +34,13 @@ export function createProfileTooltip(
           ? vscode.l10n.t('Unknown')
           : rawPlan.toUpperCase()
       const plan = escapeMarkdown(planDisplay)
+      const switchUri = buildCommandUri('codex-switch.profile.activate', [p.id])
+      const label =
+        activeId && p.id === activeId
+          ? `$(check) **${name}** - ${plan}`
+          : `${name} - ${plan}`
 
-      if (activeId && p.id === activeId) {
-        tooltip.appendMarkdown(`* **${name}** - ${plan}\n`)
-      } else {
-        tooltip.appendMarkdown(`* ${name} - ${plan}\n`)
-      }
+      tooltip.appendMarkdown(`* [${label}](${switchUri})\n`)
     }
     tooltip.appendMarkdown('\n')
   }


### PR DESCRIPTION
## Summary
- make each profile row in the status-bar tooltip clickable for direct activation
- cycle through all saved profiles from the status bar click, in the same order shown in the tooltip
- keep `Manage profiles` as the fallback entry point

## Details
This PR adds a dedicated `codex-switch.profile.activate` command and uses trusted `command:` links in the tooltip so users can switch profiles directly from the popup instead of opening the manage flow first.

It also changes the status-bar click behavior from "toggle last" to round-robin cycling across the full saved profile list, using the same sorted order used by the tooltip.

## Notes
VS Code's native `StatusBarItem.tooltip` closes automatically when a command is invoked, so this PR improves direct switching and full-list cycling but does not keep the native popup open after click.

## Verification
- `npm run compile`
- `npm run vscode:package`
- manually installed the VSIX in VS Code Server and verified:
  - profile rows in the tooltip switch directly on click
  - status-bar clicks cycle through all profiles, not only the previous one
