### PR TITLE
feat: add shared profile store for SSH remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,18 @@ It is a lightweight account manager and status bar selector.
 When you switch profiles,
 it updates `~/.codex/auth.json` so Codex CLI uses the active profile.
 
-Tokens are stored in VS Code SecretStorage.
-Profile metadata (name, email, plan) is stored in the extension global storage.
+By default, local sessions store profile credentials in VS Code SecretStorage.
+
+When the extension runs in an SSH remote session and
+`codexSwitch.storageMode` is set to `auto` (the default),
+it switches to a shared remote file store under `~/.codex-switch/`:
+
+- `profiles.json` for profile metadata
+- `profiles/<profile-id>.json` for stored auth blobs
+- `active-profile.json` for the currently selected profile
+
+The shared store is intended for teams who connect to the same remote host
+from different local machines and want profile switching to stay in sync.
 
 ## Setup
 
@@ -26,10 +36,40 @@ or use `Codex Switch: Manage Profiles` to switch, rename, or delete profiles.
 ## Settings
 
 * `codexSwitch.activeProfileScope`: `global` or `workspace`
+* `codexSwitch.storageMode`: `auto`, `secretStorage`, or `remoteFiles`
 * `codexSwitch.debugLogging`: enable debug logs (never prints tokens)
 * `codexSwitch.reloadWindowAfterProfileSwitch`: reload VS Code window
   after successful profile switch/import so Codex extension re-reads
   `auth.json` (default: `false`)
+
+### Storage Modes
+
+- `auto`: use `remoteFiles` when `vscode.env.remoteName === "ssh-remote"`,
+  otherwise use `secretStorage`
+- `secretStorage`: always keep per-profile auth data in VS Code SecretStorage
+- `remoteFiles`: always keep per-profile auth data in `~/.codex-switch/`
+
+## Shared Remote Behavior
+
+In `remoteFiles` mode, the extension treats the remote host as the source of truth.
+It watches both `~/.codex/auth.json` and the shared store under `~/.codex-switch/`
+so that if one client switches or imports a profile, other clients connected
+to the same SSH host refresh their status bar and tooltip state.
+
+When resolving the active profile in `remoteFiles` mode, the extension prefers
+the current `~/.codex/auth.json` match and keeps `active-profile.json` in sync
+with it. This makes manual `codex login` recovery and older clients safer.
+
+## Recovery
+
+If a profile exists but its stored auth blob is missing, the extension now offers:
+
+- `Recover from remote store`
+- `Import current ~/.codex/auth.json`
+- `Delete broken profile`
+
+This is mainly useful when migrating from the old SecretStorage-only behavior
+or when one client still has profile metadata but not the corresponding secrets.
 
 ## IDE Reload Behavior
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ it switches to a shared remote file store under `~/.codex-switch/`:
 The shared store is intended for teams who connect to the same remote host
 from different local machines and want profile switching to stay in sync.
 
+For a focused explanation of the SSH-specific shared store, see
+[SSH_REMOTE_STORAGE.md](./SSH_REMOTE_STORAGE.md).
+
 ## Setup
 
 To import an account, first get an `auth.json`

--- a/SSH_REMOTE_STORAGE.md
+++ b/SSH_REMOTE_STORAGE.md
@@ -1,0 +1,90 @@
+# Shared SSH Profile Store
+
+This document describes the SSH-specific shared profile store used by Codex Switch
+when `codexSwitch.storageMode` resolves to `remoteFiles`.
+
+## Why This Exists
+
+VS Code SecretStorage is client-scoped, which means two different local machines
+connected to the same SSH remote can see the same remote workspace but still have
+different secret payloads for the extension.
+
+That leads to split-brain behavior:
+
+- the remote host has one `~/.codex/auth.json`
+- the profile list may appear shared
+- the stored tokens may still differ between clients
+
+The shared SSH profile store makes the remote host the source of truth.
+
+## Storage Layout
+
+The shared store lives under:
+
+```text
+~/.codex-switch/
+```
+
+Files:
+
+- `profiles.json` - profile metadata
+- `profiles/<profile-id>.json` - stored auth blob for each profile
+- `active-profile.json` - the currently selected profile
+
+Directories are created with `0700` and files are written with `0600`.
+
+## Storage Modes
+
+- `auto`
+  - use `remoteFiles` when `vscode.env.remoteName === "ssh-remote"`
+  - otherwise use `secretStorage`
+- `secretStorage`
+  - keep per-profile auth data in VS Code SecretStorage
+- `remoteFiles`
+  - keep per-profile auth data in `~/.codex-switch/`
+
+## Source Of Truth
+
+In `remoteFiles` mode, the extension reconciles active state from:
+
+1. the current `~/.codex/auth.json`
+2. `active-profile.json`
+
+If `auth.json` clearly matches one of the saved profiles, that match wins and
+`active-profile.json` is updated to follow it.
+
+This keeps the extension aligned with:
+
+- manual `codex login`
+- profile switching from another client
+- older clients that only touched `auth.json`
+
+## Sync Between Clients
+
+The extension watches:
+
+- `~/.codex/auth.json`
+- `~/.codex-switch/profiles.json`
+- `~/.codex-switch/active-profile.json`
+- `~/.codex-switch/profiles/*.json`
+
+When any of these files change, connected clients refresh their status bar and
+tooltip state.
+
+## Recovery Flow
+
+If a profile exists but its stored auth blob is missing, the extension offers:
+
+- `Recover from remote store`
+- `Import current ~/.codex/auth.json`
+- `Delete broken profile`
+
+This is intended to make migration from the older SecretStorage-only model less
+fragile when users move between local machines.
+
+## Operational Guidance
+
+Use `remoteFiles` only for trusted SSH remotes where sharing profile state across
+clients is actually desired.
+
+For local-only usage, `secretStorage` remains the safer model.

--- a/package.json
+++ b/package.json
@@ -94,6 +94,16 @@
           "default": "global",
           "description": "%configuration.activeProfileScope.description%"
         },
+        "codexSwitch.storageMode": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "secretStorage",
+            "remoteFiles"
+          ],
+          "default": "auto",
+          "description": "%configuration.storageMode.description%"
+        },
         "codexSwitch.reloadWindowAfterProfileSwitch": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
   "configuration.title": "Codex Switch",
   "configuration.debugLogging.description": "Enable verbose logging (never prints tokens)",
   "configuration.activeProfileScope.description": "Where to store active profile selection",
+  "configuration.storageMode.description": "Where profile credentials are stored. In auto mode, SSH remote sessions use a shared remote file store and local sessions use SecretStorage",
   "configuration.reloadWindowAfterProfileSwitch.description": "Reload VS Code window after successful profile switch/import so Codex extension re-reads auth.json",
   "configuration.maxAuthBackups.description": "Maximum number of auth.json backups to keep (0 disables backups)",
   "command.login.title": "Codex Switch: Login Help",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -4,6 +4,7 @@
   "configuration.title": "Codex Switch",
   "configuration.debugLogging.description": "Включить подробные логи (токены не выводятся)",
   "configuration.activeProfileScope.description": "Где хранить выбор активного профиля",
+  "configuration.storageMode.description": "Где хранить учетные данные профилей. В режиме auto для SSH remote используется общее файловое хранилище на сервере, а локально используется SecretStorage",
   "configuration.reloadWindowAfterProfileSwitch.description": "Перезагружать окно VS Code после успешного переключения/импорта профиля, чтобы расширение Codex перечитало auth.json",
   "configuration.maxAuthBackups.description": "Максимальное количество бэкапов auth.json (0 отключает бэкапы)",
   "command.login.title": "Codex Switch: Помощь по входу",

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -22,11 +22,17 @@ function parseJWT(token: string): any {
 }
 
 /**
+ * Resolve default Codex home path.
+ */
+export function getDefaultCodexHomePath(): string {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
+}
+
+/**
  * Resolve default Codex auth file path.
  */
 export function getDefaultCodexAuthPath(): string {
-  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
-  return path.join(codexHome, 'auth.json')
+  return path.join(getDefaultCodexHomePath(), 'auth.json')
 }
 
 export async function loadAuthDataFromFile(

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -2,9 +2,22 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import { randomUUID } from 'crypto'
-import { AuthData, ProfileSummary } from '../types'
-import { getDefaultCodexAuthPath } from './auth-manager'
+import { AuthData, ProfileSummary, StorageMode } from '../types'
+import { getDefaultCodexAuthPath, loadAuthDataFromFile } from './auth-manager'
 import { syncCodexAuthFile } from './codex-auth-sync'
+import {
+  SharedActiveProfile,
+  SHARED_ACTIVE_PROFILE_FILENAME,
+  deleteFileIfExists,
+  ensureSharedStoreDirs,
+  getSharedActiveProfilePath,
+  getSharedProfileSecretsPath,
+  getSharedProfilesDir,
+  getSharedProfilesPath,
+  getSharedStoreRoot,
+  readJsonFile,
+  writeJsonFile,
+} from './shared-profile-store'
 
 type ProfileTokens = Pick<
   AuthData,
@@ -31,6 +44,29 @@ export class ProfileManager {
   constructor(private context: vscode.ExtensionContext) {}
 
   private lastSyncedProfileId: string | undefined
+
+  private getConfiguredStorageMode(): StorageMode {
+    const cfg = vscode.workspace.getConfiguration('codexSwitch')
+    const raw = cfg.get<StorageMode>('storageMode', 'auto')
+    if (raw === 'secretStorage' || raw === 'remoteFiles' || raw === 'auto') {
+      return raw
+    }
+    return 'auto'
+  }
+
+  private getResolvedStorageMode(): Exclude<StorageMode, 'auto'> {
+    const configured = this.getConfiguredStorageMode()
+    if (configured === 'auto') {
+      return vscode.env.remoteName === 'ssh-remote'
+        ? 'remoteFiles'
+        : 'secretStorage'
+    }
+    return configured
+  }
+
+  private isRemoteFilesMode(): boolean {
+    return this.getResolvedStorageMode() === 'remoteFiles'
+  }
 
   private getMaxAuthBackups(): number {
     const cfg = vscode.workspace.getConfiguration('codexSwitch')
@@ -74,14 +110,25 @@ export class ProfileManager {
   }
 
   private getStorageDir(): string {
+    if (this.isRemoteFilesMode()) {
+      return getSharedStoreRoot()
+    }
     return this.context.globalStorageUri.fsPath
   }
 
   private getProfilesPath(): string {
+    if (this.isRemoteFilesMode()) {
+      return getSharedProfilesPath()
+    }
     return path.join(this.getStorageDir(), PROFILES_FILENAME)
   }
 
   private ensureStorageDir() {
+    if (this.isRemoteFilesMode()) {
+      ensureSharedStoreDirs()
+      return
+    }
+
     const dir = this.getStorageDir()
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true })
@@ -117,6 +164,11 @@ export class ProfileManager {
     }
 
     try {
+      if (this.isRemoteFilesMode()) {
+        const parsed = readJsonFile<any>(filePath)
+        if (parsed == null) return { version: 1, profiles: [] }
+        return this.parseProfilesFile(JSON.stringify(parsed))
+      }
       const raw = fs.readFileSync(filePath, 'utf8')
       return this.parseProfilesFile(raw)
     } catch {
@@ -127,6 +179,11 @@ export class ProfileManager {
 
   private writeProfilesFile(data: ProfilesFileV1) {
     this.ensureStorageDir()
+    if (this.isRemoteFilesMode()) {
+      writeJsonFile(this.getProfilesPath(), data)
+      return
+    }
+
     fs.writeFileSync(this.getProfilesPath(), JSON.stringify(data, null, 2), {
       encoding: 'utf8',
     })
@@ -140,9 +197,68 @@ export class ProfileManager {
     return `${OLD_SECRET_PREFIX}${profileId}`
   }
 
+  private readSharedActiveProfile(): SharedActiveProfile | null {
+    if (!this.isRemoteFilesMode()) return null
+    return readJsonFile<SharedActiveProfile>(getSharedActiveProfilePath())
+  }
+
+  private writeSharedActiveProfile(profileId: string): void {
+    if (!this.isRemoteFilesMode()) return
+    writeJsonFile(getSharedActiveProfilePath(), {
+      profileId,
+      updatedAt: new Date().toISOString(),
+    } satisfies SharedActiveProfile)
+  }
+
+  private deleteSharedActiveProfile(): void {
+    if (!this.isRemoteFilesMode()) return
+    deleteFileIfExists(getSharedActiveProfilePath())
+  }
+
+  private readRemoteProfileTokens(profileId: string): ProfileTokens | null {
+    return readJsonFile<ProfileTokens>(getSharedProfileSecretsPath(profileId))
+  }
+
+  private async readStoredTokens(profileId: string): Promise<ProfileTokens | null> {
+    if (this.isRemoteFilesMode()) {
+      return this.readRemoteProfileTokens(profileId)
+    }
+
+    const raw =
+      (await this.context.secrets.get(this.secretKey(profileId))) ||
+      (await this.context.secrets.get(this.legacySecretKey(profileId)))
+    if (!raw) return null
+
+    try {
+      return JSON.parse(raw) as ProfileTokens
+    } catch {
+      return null
+    }
+  }
+
+  private async writeStoredTokens(profileId: string, tokens: ProfileTokens): Promise<void> {
+    if (this.isRemoteFilesMode()) {
+      ensureSharedStoreDirs()
+      writeJsonFile(getSharedProfileSecretsPath(profileId), tokens)
+      return
+    }
+
+    await this.context.secrets.store(this.secretKey(profileId), JSON.stringify(tokens))
+  }
+
+  private async deleteStoredTokens(profileId: string): Promise<void> {
+    if (this.isRemoteFilesMode()) {
+      deleteFileIfExists(getSharedProfileSecretsPath(profileId))
+      return
+    }
+
+    await this.context.secrets.delete(this.secretKey(profileId))
+    await this.context.secrets.delete(this.legacySecretKey(profileId))
+  }
+
   private getGlobalStorageRoot(): string {
     // .../User/globalStorage/<publisher.name> -> .../User/globalStorage
-    return path.dirname(this.getStorageDir())
+    return path.dirname(this.context.globalStorageUri.fsPath)
   }
 
   private async tryMigrateLegacyProfilesOnce(): Promise<void> {
@@ -225,9 +341,69 @@ export class ProfileManager {
     return profiles.find((p) => p.id === profileId)
   }
 
+  private async inferActiveProfileIdFromAuthFile(): Promise<string | undefined> {
+    const authData = await loadAuthDataFromFile(getDefaultCodexAuthPath())
+    if (!authData) return undefined
+
+    const file = await this.readProfilesFile()
+    const match = file.profiles.find((p) => this.matchesAuth(p, authData))
+    return match?.id
+  }
+
   async findDuplicateProfile(authData: AuthData): Promise<ProfileSummary | undefined> {
     const file = await this.readProfilesFile()
     return file.profiles.find((p) => this.matchesAuth(p, authData))
+  }
+
+  private async recoverMissingTokens(profileId: string): Promise<AuthData | null> {
+    const profile = await this.getProfile(profileId)
+    const recoverLabel = vscode.l10n.t('Recover from remote store')
+    const importLabel = vscode.l10n.t('Import current ~/.codex/auth.json')
+    const deleteLabel = vscode.l10n.t('Delete broken profile')
+
+    const canRecoverFromRemote =
+      !this.isRemoteFilesMode() &&
+      this.readRemoteProfileTokens(profileId) != null
+
+    const pick = await vscode.window.showWarningMessage(
+      vscode.l10n.t(
+        'Profile "{0}" is missing tokens. Restore it before switching.',
+        profile?.name || profileId,
+      ),
+      { modal: true },
+      ...(canRecoverFromRemote ? [recoverLabel] : []),
+      importLabel,
+      deleteLabel,
+    )
+
+    if (pick === recoverLabel) {
+      const tokens = this.readRemoteProfileTokens(profileId)
+      if (tokens) {
+        await this.writeStoredTokens(profileId, tokens)
+        return this.loadAuthData(profileId)
+      }
+    }
+
+    if (pick === importLabel) {
+      const authData = await loadAuthDataFromFile(getDefaultCodexAuthPath())
+      if (!authData) {
+        void vscode.window.showErrorMessage(
+          vscode.l10n.t(
+            'Could not read auth from {0}. Run "codex login" first.',
+            getDefaultCodexAuthPath(),
+          ),
+        )
+        return null
+      }
+      await this.replaceProfileAuth(profileId, authData)
+      return authData
+    }
+
+    if (pick === deleteLabel) {
+      await this.deleteProfile(profileId)
+    }
+
+    return null
   }
 
   async replaceProfileAuth(profileId: string, authData: AuthData): Promise<boolean> {
@@ -251,7 +427,7 @@ export class ProfileManager {
       accountId: authData.accountId,
       authJson: authData.authJson,
     }
-    await this.context.secrets.store(this.secretKey(profileId), JSON.stringify(tokens))
+    await this.writeStoredTokens(profileId, tokens)
     return true
   }
 
@@ -293,7 +469,7 @@ export class ProfileManager {
       accountId: authData.accountId,
       authJson: authData.authJson,
     }
-    await this.context.secrets.store(this.secretKey(id), JSON.stringify(tokens))
+    await this.writeStoredTokens(id, tokens)
 
     return profile
   }
@@ -318,8 +494,7 @@ export class ProfileManager {
     if (file.profiles.length === before) return false
     this.writeProfilesFile(file)
 
-    await this.context.secrets.delete(this.secretKey(profileId))
-    await this.context.secrets.delete(this.legacySecretKey(profileId))
+    await this.deleteStoredTokens(profileId)
 
     // Clean up active/last if they point to deleted profile.
     const active = await this.getActiveProfileId()
@@ -332,24 +507,17 @@ export class ProfileManager {
   async loadAuthData(profileId: string): Promise<AuthData | null> {
     const profile = await this.getProfile(profileId)
     if (!profile) return null
-    const raw =
-      (await this.context.secrets.get(this.secretKey(profileId))) ||
-      (await this.context.secrets.get(this.legacySecretKey(profileId)))
-    if (!raw) return null
+    const tokens = await this.readStoredTokens(profileId)
+    if (!tokens) return null
 
-    try {
-      const tokens = JSON.parse(raw) as ProfileTokens
-      return {
-        idToken: tokens.idToken,
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        accountId: tokens.accountId,
-        email: profile.email,
-        planType: profile.planType,
-        authJson: tokens.authJson,
-      }
-    } catch {
-      return null
+    return {
+      idToken: tokens.idToken,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      accountId: tokens.accountId,
+      email: profile.email,
+      planType: profile.planType,
+      authJson: tokens.authJson,
     }
   }
 
@@ -372,6 +540,20 @@ export class ProfileManager {
   }
 
   async getActiveProfileId(): Promise<string | undefined> {
+    if (this.isRemoteFilesMode()) {
+      const explicit = this.readSharedActiveProfile()?.profileId
+      const inferred = await this.inferActiveProfileIdFromAuthFile()
+
+      if (inferred) {
+        if (explicit !== inferred) {
+          this.writeSharedActiveProfile(inferred)
+        }
+        return inferred
+      }
+
+      return explicit
+    }
+
     const bucket = this.getStateBucket()
     const v = bucket.get<string>(ACTIVE_PROFILE_KEY)
     if (v) return v
@@ -393,29 +575,34 @@ export class ProfileManager {
   async setActiveProfileId(profileId: string | undefined): Promise<boolean> {
     const bucket = this.getStateBucket()
     const prev =
-      bucket.get<string>(ACTIVE_PROFILE_KEY) ||
-      bucket.get<string>(OLD_ACTIVE_PROFILE_KEY)
+      (this.isRemoteFilesMode()
+        ? await this.getActiveProfileId()
+        : bucket.get<string>(ACTIVE_PROFILE_KEY) ||
+          bucket.get<string>(OLD_ACTIVE_PROFILE_KEY))
 
     let authData: AuthData | null = null
     if (profileId) {
       authData = await this.loadAuthData(profileId)
       if (!authData) {
-        const p = await this.getProfile(profileId)
-        void vscode.window.showErrorMessage(
-          vscode.l10n.t(
-            'Profile "{0}" is missing tokens. Re-import auth.json to replace it.',
-            p?.name || profileId,
-          ),
-        )
-        return false
+        authData = await this.recoverMissingTokens(profileId)
+        if (!authData) return false
       }
     }
 
     if (prev && profileId && prev !== profileId) {
       await this.setLastProfileId(prev)
     }
-    await bucket.update(ACTIVE_PROFILE_KEY, profileId)
-    await bucket.update(OLD_ACTIVE_PROFILE_KEY, undefined)
+
+    if (this.isRemoteFilesMode()) {
+      if (profileId) {
+        this.writeSharedActiveProfile(profileId)
+      } else {
+        this.deleteSharedActiveProfile()
+      }
+    } else {
+      await bucket.update(ACTIVE_PROFILE_KEY, profileId)
+      await bucket.update(OLD_ACTIVE_PROFILE_KEY, undefined)
+    }
 
     if (profileId && authData) {
       // We already validated tokens above; avoid a second secret read.
@@ -468,5 +655,59 @@ export class ProfileManager {
     const active = await this.getActiveProfileId()
     if (!active) return
     await this.maybeSyncToCodexAuthFile(active)
+  }
+
+  createWatchers(onChanged: () => void): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = []
+    const fire = () => {
+      try {
+        onChanged()
+      } catch {
+        // ignore refresh errors from file watchers
+      }
+    }
+
+    const authDir = path.dirname(getDefaultCodexAuthPath())
+    const authWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(vscode.Uri.file(authDir), 'auth.json'),
+    )
+    authWatcher.onDidCreate(fire)
+    authWatcher.onDidChange(fire)
+    authWatcher.onDidDelete(fire)
+    disposables.push(authWatcher)
+
+    if (this.isRemoteFilesMode()) {
+      const profilesWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(
+          vscode.Uri.file(getSharedStoreRoot()),
+          PROFILES_FILENAME,
+        ),
+      )
+      profilesWatcher.onDidCreate(fire)
+      profilesWatcher.onDidChange(fire)
+      profilesWatcher.onDidDelete(fire)
+      disposables.push(profilesWatcher)
+
+      const activeWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(
+          vscode.Uri.file(getSharedStoreRoot()),
+          SHARED_ACTIVE_PROFILE_FILENAME,
+        ),
+      )
+      activeWatcher.onDidCreate(fire)
+      activeWatcher.onDidChange(fire)
+      activeWatcher.onDidDelete(fire)
+      disposables.push(activeWatcher)
+
+      const tokenWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(vscode.Uri.file(getSharedProfilesDir()), '*.json'),
+      )
+      tokenWatcher.onDidCreate(fire)
+      tokenWatcher.onDidChange(fire)
+      tokenWatcher.onDidDelete(fire)
+      disposables.push(tokenWatcher)
+    }
+
+    return disposables
   }
 }

--- a/src/auth/shared-profile-store.ts
+++ b/src/auth/shared-profile-store.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+export const SHARED_STORE_DIRNAME = '.codex-switch'
+export const SHARED_PROFILES_DIRNAME = 'profiles'
+export const SHARED_PROFILES_FILENAME = 'profiles.json'
+export const SHARED_ACTIVE_PROFILE_FILENAME = 'active-profile.json'
+
+export interface SharedActiveProfile {
+  profileId: string
+  updatedAt: string
+}
+
+export function getSharedStoreRoot(): string {
+  return path.join(os.homedir(), SHARED_STORE_DIRNAME)
+}
+
+export function getSharedProfilesDir(): string {
+  return path.join(getSharedStoreRoot(), SHARED_PROFILES_DIRNAME)
+}
+
+export function getSharedProfilesPath(): string {
+  return path.join(getSharedStoreRoot(), SHARED_PROFILES_FILENAME)
+}
+
+export function getSharedActiveProfilePath(): string {
+  return path.join(getSharedStoreRoot(), SHARED_ACTIVE_PROFILE_FILENAME)
+}
+
+export function getSharedProfileSecretsPath(profileId: string): string {
+  return path.join(getSharedProfilesDir(), `${profileId}.json`)
+}
+
+export function ensureSharedStoreDirs(): void {
+  fs.mkdirSync(getSharedStoreRoot(), { recursive: true, mode: 0o700 })
+  fs.mkdirSync(getSharedProfilesDir(), { recursive: true, mode: 0o700 })
+}
+
+export function readJsonFile<T>(filePath: string): T | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+export function writeJsonFile(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath)
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+}
+
+export function deleteFileIfExists(filePath: string): void {
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath)
+    }
+  } catch {
+    // ignore cleanup failures
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,9 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   registerCommands(context, profileManager, refreshUi)
+  context.subscriptions.push(...profileManager.createWatchers(() => {
+    void refreshUi()
+  }))
   void refreshUi()
   void profileManager.syncActiveProfileToCodexAuthFile()
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface AuthData {
     authJson?: Record<string, unknown>;
 }
 
+export type StorageMode = 'auto' | 'secretStorage' | 'remoteFiles';
+
 export interface ProfileSummary {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary
- add `codexSwitch.storageMode` with `auto`, `secretStorage`, and `remoteFiles`
- make `auto` resolve to `remoteFiles` when `vscode.env.remoteName === "ssh-remote"`
- add a shared remote profile store under `~/.codex-switch/` for SSH remote usage
- keep local/non-SSH usage on VS Code SecretStorage
- add recovery actions when a profile exists but its stored auth blob is missing
- watch `~/.codex/auth.json` and the shared profile store so multiple clients on the same SSH host refresh their UI when one client switches/imports a profile

## Shared remote store layout
- `~/.codex-switch/profiles.json`
- `~/.codex-switch/profiles/<profile-id>.json`
- `~/.codex-switch/active-profile.json`

## Behavior
In `remoteFiles` mode, the extension treats the remote host as the source of truth. The active profile is reconciled from the current `~/.codex/auth.json` when possible, with `active-profile.json` kept in sync as the shared cache.

If a profile exists but its auth blob is missing, the extension now offers:
- `Recover from remote store`
- `Import current ~/.codex/auth.json`
- `Delete broken profile`

## Verification
- `npm run compile`
- `npm run vscode:package`

## Notes
This PR is intentionally scoped to SSH remote collaboration. It does not change the local single-client security model by default; local sessions still use SecretStorage unless `storageMode` is explicitly overridden.
