### PR TITLE
Fix false profile matches and resolve auth.json from the active Codex environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ multiple Codex accounts organized and makes switching between them fast
 (for example "work" and "personal").  
 It is a lightweight account manager and status bar selector.
 When you switch profiles,
-it updates `~/.codex/auth.json` so Codex CLI uses the active profile.
+it updates the current environment `auth.json` so Codex CLI uses the active profile.
+On Windows, if `chatgpt.runCodexInWindowsSubsystemForLinux` is enabled, this uses
+the WSL-side `~/.codex/auth.json`; otherwise it uses the Windows/local one.
 
 Tokens are stored in VS Code SecretStorage.
 Profile metadata (name, email, plan) is stored in the extension global storage.
@@ -13,15 +15,20 @@ Profile metadata (name, email, plan) is stored in the extension global storage.
 ## Setup
 
 To import an account, first get an `auth.json`
-(the easiest way is `codex login` which creates `~/.codex/auth.json`).
+(the easiest way is `codex login` in your current Codex environment, or
+`wsl codex login` on Windows when `chatgpt.runCodexInWindowsSubsystemForLinux` is enabled).
 Then run `Codex Switch: Manage Profiles` and choose
-"Add From ~/.codex/auth.json" or "Import From File...".
+"Add From Current auth.json" or "Import From File...".
 
 ## Usage
 
 The status bar shows `$(account) <profile>`.
 Click it to toggle to the last used profile,
 or use `Codex Switch: Manage Profiles` to switch, rename, or delete profiles.
+
+Duplicate detection matches user identity (`chatgptUserId`, `userId`, JWT `sub`,
+then email fallback), so different users in the same Team/Business account can
+coexist as separate profiles.
 
 ## Settings
 

--- a/src/auth/auth-manager.ts
+++ b/src/auth/auth-manager.ts
@@ -1,8 +1,16 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import * as vscode from 'vscode'
+import { execFileSync } from 'child_process'
 import { AuthData } from '../types'
 import { errorLog } from '../utils/log'
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const v = value.trim()
+  return v ? v : undefined
+}
 
 /**
  * Parse JWT token to extract payload
@@ -26,7 +34,34 @@ function parseJWT(token: string): any {
  */
 export function getDefaultCodexAuthPath(): string {
   const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex')
-  return path.join(codexHome, 'auth.json')
+  const localPath = path.join(codexHome, 'auth.json')
+  if (!shouldUseWslAuthPath()) return localPath
+
+  const wslPath = resolveWslDefaultCodexAuthPath()
+  return wslPath || localPath
+}
+
+export function shouldUseWslAuthPath(): boolean {
+  if (process.platform !== 'win32') return false
+  return !!vscode.workspace
+    .getConfiguration('chatgpt')
+    .get<boolean>('runCodexInWindowsSubsystemForLinux', false)
+}
+
+function resolveWslDefaultCodexAuthPath(): string | null {
+  try {
+    // Convert WSL ~/.codex/auth.json to a Windows path (for example \\wsl$\<distro>\...).
+    const out = execFileSync(
+      'wsl.exe',
+      ['sh', '-lc', 'wslpath -w ~/.codex/auth.json'],
+      { encoding: 'utf8', windowsHide: true },
+    )
+    const p = String(out || '').trim()
+    return p || null
+  } catch (error) {
+    errorLog('Error resolving WSL auth file path:', error)
+    return null
+  }
 }
 
 export async function loadAuthDataFromFile(
@@ -46,16 +81,18 @@ export async function loadAuthDataFromFile(
 
     // Parse ID token to get user info
     const idTokenPayload = parseJWT(authJson.tokens.id_token)
+    const authPayload = idTokenPayload['https://api.openai.com/auth']
 
     return {
       idToken: authJson.tokens.id_token,
       accessToken: authJson.tokens.access_token,
       refreshToken: authJson.tokens.refresh_token,
       accountId: authJson.tokens.account_id,
+      chatgptUserId: asNonEmptyString(authPayload?.chatgpt_user_id),
+      userId: asNonEmptyString(authPayload?.user_id),
+      subject: asNonEmptyString(idTokenPayload.sub),
       email: idTokenPayload.email || 'Unknown',
-      planType:
-        idTokenPayload['https://api.openai.com/auth']?.chatgpt_plan_type ||
-        'Unknown',
+      planType: authPayload?.chatgpt_plan_type || 'Unknown',
       authJson,
     }
   } catch (error) {

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -44,10 +44,34 @@ export class ProfileManager {
     return String(email || '').trim().toLowerCase()
   }
 
+  private normalizeIdentity(value: string | undefined): string {
+    return String(value || '').trim()
+  }
+
+  private compareIdentityField(
+    profileValue: string | undefined,
+    authValue: string | undefined,
+  ): boolean | undefined {
+    const p = this.normalizeIdentity(profileValue)
+    const a = this.normalizeIdentity(authValue)
+    if (!p || !a) return undefined
+    return p === a
+  }
+
   private matchesAuth(profile: ProfileSummary, authData: AuthData): boolean {
-    if (authData.accountId && profile.accountId && authData.accountId === profile.accountId) {
-      return true
-    }
+    // Team/Business tenants can share account_id across different users.
+    // Match by user identity fields first, then email as a final fallback.
+    const chatgptUserIdMatch = this.compareIdentityField(
+      profile.chatgptUserId,
+      authData.chatgptUserId,
+    )
+    if (chatgptUserIdMatch !== undefined) return chatgptUserIdMatch
+
+    const userIdMatch = this.compareIdentityField(profile.userId, authData.userId)
+    if (userIdMatch !== undefined) return userIdMatch
+
+    const subjectMatch = this.compareIdentityField(profile.subject, authData.subject)
+    if (subjectMatch !== undefined) return subjectMatch
 
     const pe = this.normalizeEmail(profile.email)
     const ae = this.normalizeEmail(authData.email)
@@ -223,6 +247,9 @@ export class ProfileManager {
       email: authData.email,
       planType: authData.planType,
       accountId: authData.accountId,
+      chatgptUserId: authData.chatgptUserId,
+      userId: authData.userId,
+      subject: authData.subject,
       updatedAt: new Date().toISOString(),
     }
     this.writeProfilesFile(file)
@@ -261,6 +288,9 @@ export class ProfileManager {
       email: authData.email,
       planType: authData.planType,
       accountId: authData.accountId,
+      chatgptUserId: authData.chatgptUserId,
+      userId: authData.userId,
+      subject: authData.subject,
       createdAt: now,
       updatedAt: now,
     }
@@ -326,7 +356,10 @@ export class ProfileManager {
         idToken: tokens.idToken,
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,
-        accountId: tokens.accountId,
+        accountId: tokens.accountId || profile.accountId,
+        chatgptUserId: profile.chatgptUserId,
+        userId: profile.userId,
+        subject: profile.subject,
         email: profile.email,
         planType: profile.planType,
         authJson: tokens.authJson,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,7 +2,11 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
 import { ProfileManager } from '../auth/profile-manager'
-import { getDefaultCodexAuthPath, loadAuthDataFromFile } from '../auth/auth-manager'
+import {
+  getDefaultCodexAuthPath,
+  loadAuthDataFromFile,
+  shouldUseWslAuthPath,
+} from '../auth/auth-manager'
 
 /**
  * Register all extension commands
@@ -20,16 +24,24 @@ export function registerCommands(
     await vscode.commands.executeCommand('workbench.action.reloadWindow')
   }
 
+  const getLoginCommandText = (): string =>
+    shouldUseWslAuthPath() ? 'wsl codex login' : 'codex login'
+
   // Login command
   const loginCommand = vscode.commands.registerCommand(
     'codex-switch.login',
     async () => {
+      const loginCommandText = getLoginCommandText()
+      const loginSequence = `${loginCommandText}\n`
       const manageLabel = vscode.l10n.t('Manage profiles')
       const openTerminalLabel = vscode.l10n.t('Open terminal')
       const copyCommandLabel = vscode.l10n.t('Copy command')
 
       const selection = await vscode.window.showInformationMessage(
-        vscode.l10n.t('Authentication required. Add a profile or run "codex login".'),
+        vscode.l10n.t(
+          'Authentication required. Add a profile or run "{0}".',
+          loginCommandText,
+        ),
         manageLabel,
         openTerminalLabel,
         copyCommandLabel,
@@ -43,14 +55,14 @@ export function registerCommands(
           vscode.commands.executeCommand(
             'workbench.action.terminal.sendSequence',
             {
-              text: 'codex login\n',
+              text: loginSequence,
             },
           )
         }, 500)
       } else if (selection === copyCommandLabel) {
-        vscode.env.clipboard.writeText('codex login')
+        vscode.env.clipboard.writeText(loginCommandText)
         vscode.window.showInformationMessage(
-          vscode.l10n.t('Command "codex login" copied to clipboard.'),
+          vscode.l10n.t('Command "{0}" copied to clipboard.', loginCommandText),
         )
       }
     },
@@ -102,12 +114,14 @@ export function registerCommands(
     'codex-switch.profile.addFromCodexAuthFile',
     async () => {
       const authPath = getDefaultCodexAuthPath()
+      const loginCommandText = getLoginCommandText()
       const authData = await loadAuthDataFromFile(authPath)
       if (!authData) {
         vscode.window.showErrorMessage(
           vscode.l10n.t(
-            'Could not read auth from {0}. Run "codex login" first.',
+            'Could not read auth from {0}. Run "{1}" first.',
             authPath,
+            loginCommandText,
           ),
         )
         return
@@ -156,11 +170,12 @@ export function registerCommands(
     'codex-switch.profile.login',
     async () => {
       const authPath = getDefaultCodexAuthPath()
+      const loginSequence = `${getLoginCommandText()}\n`
 
       vscode.commands.executeCommand('workbench.action.terminal.new')
       setTimeout(() => {
         vscode.commands.executeCommand('workbench.action.terminal.sendSequence', {
-          text: 'codex login\n',
+          text: loginSequence,
         })
       }, 500)
 
@@ -186,7 +201,10 @@ export function registerCommands(
         cleanup()
         const importLabel = vscode.l10n.t('Import')
         const pick = await vscode.window.showInformationMessage(
-          vscode.l10n.t('Codex auth file detected. Import it as a profile?'),
+          vscode.l10n.t(
+            'Codex auth file detected at {0}. Import it as a profile?',
+            authPath,
+          ),
           importLabel,
         )
         if (pick === importLabel) {
@@ -220,7 +238,8 @@ export function registerCommands(
       const manageLabel = vscode.l10n.t('Manage profiles')
       const msg = await vscode.window.showInformationMessage(
         vscode.l10n.t(
-          'After completing the login flow, import ~/.codex/auth.json as a profile.',
+          'After completing the login flow, import the current environment auth.json from {0} as a profile.',
+          authPath,
         ),
         importNowLabel,
         manageLabel,
@@ -355,6 +374,7 @@ export function registerCommands(
   const manageProfilesCommand = vscode.commands.registerCommand(
     'codex-switch.profile.manage',
     async () => {
+      const authPath = getDefaultCodexAuthPath()
       const profiles = await profileManager.listProfiles()
       const hasProfiles = profiles.length > 0
 
@@ -373,7 +393,8 @@ export function registerCommands(
               ]
             : []),
           {
-            label: vscode.l10n.t('Add from ~/.codex/auth.json'),
+            label: vscode.l10n.t('Add from current auth.json'),
+            description: authPath,
             command: 'codex-switch.profile.addFromCodexAuthFile',
           },
           {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,9 @@ export interface AuthData {
     accessToken: string;
     refreshToken: string;
     accountId?: string;
+    chatgptUserId?: string;
+    userId?: string;
+    subject?: string;
     email: string;
     planType: string;
     authJson?: Record<string, unknown>;
@@ -14,6 +17,9 @@ export interface ProfileSummary {
     email: string;
     planType: string;
     accountId?: string;
+    chatgptUserId?: string;
+    userId?: string;
+    subject?: string;
     createdAt: string;
     updatedAt: string;
 }


### PR DESCRIPTION
This PR fixes two issues related to profile detection and auth file resolution.
In certain environments, the extension could load the wrong `auth.json` or incorrectly treat different users as the same profile. These problems were particularly visible in **Windows + WSL setups** and **Business/Team accounts**.
The changes improve environment detection and strengthen the identity logic used to match profiles.

# 1. Windows + WSL auth.json resolution

## The bug
The extension previously assumed a single host environment and attempted to load the auth file from the Windows path.

This could lead to situations where:
* Codex CLI was authenticated correctly (inside WSL)
* but Codex Switch attempted to import profiles from the **wrong auth.json** (from Windows environment)
This created confusing behavior where profile import did not reflect the active authenticated user.

## The fix
The extension now:
* detects the Codex configuration setting that controls whether Codex runs in WSL
* automatically resolves the correct environment
* loads `auth.json` from the correct location:
  * **WSL home directory** when Codex runs in WSL
  * **Windows home directory** otherwise
This ensures that profile import always reads the **same credentials file used by the Codex CLI runtime**.

# 2. Business / Team accounts incorrectly detected as duplicate users

## The bug
In Busiiness account, multiple users can share higher-level account identifiers.
The previous identity matching logic relied on fields that were not sufficiently unique across users in these environments. As a result:
* different users could be incorrectly treated as the **same profile**
* importing profiles could overwrite or match an existing profile incorrectly

## The fix
The identity logic has been expanded to use stronger user-level identifiers extracted from the auth token.
Additional identity fields are now persisted and used when matching profiles, including:
* ChatGPT user identifier
* internal user identifier
* JWT subject (`sub`)
* email as a fallback
Profile matching now prioritizes **user-level identifiers instead of broader account identifiers**, preventing false matches between distinct users within the same organization.