### PR TITLE
Use extension host restart after profile switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Main settings:
 * `codexSwitch.reloadWindowAfterProfileSwitch`
 * `codexSwitch.statusBarClickBehavior` (`cycle` or `toggleLast`)
 
+When `codexSwitch.reloadWindowAfterProfileSwitch` is enabled, the extension now tries to restart only the extension host after a successful switch/import so Codex re-reads `auth.json` without reloading the full VS Code window. If that command is unavailable, it falls back to a full window reload.
+
 ## Security Notes
 
 For local single-client use, `secretStorage` is the safer default.

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,7 +5,7 @@
   "configuration.debugLogging.description": "Enable verbose logging (never prints tokens)",
   "configuration.activeProfileScope.description": "Where to store active profile selection",
   "configuration.storageMode.description": "Where profile credentials are stored. In auto mode, SSH remote sessions use a shared remote file store and local sessions use SecretStorage",
-  "configuration.reloadWindowAfterProfileSwitch.description": "Restart the extension host after successful profile switch/import so Codex re-reads auth.json without reloading the full VS Code window",
+  "configuration.reloadWindowAfterProfileSwitch.description": "Restart the VS Code extension host after successful profile switch/import; fall back to reloading the window so the Codex extension re-reads auth.json",
   "configuration.statusBarClickBehavior.description": "Behavior when clicking the status bar profile item",
   "configuration.statusBarClickBehavior.cycle": "Cycle through all saved profiles",
   "configuration.statusBarClickBehavior.toggleLast": "Toggle between current and previous profile",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,7 +5,7 @@
   "configuration.debugLogging.description": "Enable verbose logging (never prints tokens)",
   "configuration.activeProfileScope.description": "Where to store active profile selection",
   "configuration.storageMode.description": "Where profile credentials are stored. In auto mode, SSH remote sessions use a shared remote file store and local sessions use SecretStorage",
-  "configuration.reloadWindowAfterProfileSwitch.description": "Reload VS Code window after successful profile switch/import so Codex extension re-reads auth.json",
+  "configuration.reloadWindowAfterProfileSwitch.description": "Restart the extension host after successful profile switch/import so Codex re-reads auth.json without reloading the full VS Code window",
   "configuration.statusBarClickBehavior.description": "Behavior when clicking the status bar profile item",
   "configuration.statusBarClickBehavior.cycle": "Cycle through all saved profiles",
   "configuration.statusBarClickBehavior.toggleLast": "Toggle between current and previous profile",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -13,7 +13,7 @@
   "command.profile.addFromFile.title": "Codex Switch: Importar de arquivo",
   "command.profile.rename.title": "Codex Switch: Renomear perfil",
   "command.profile.delete.title": "Codex Switch: Excluir perfil",
-  "configuration.reloadWindowAfterProfileSwitch.description": "Reiniciar o host de extensoes apos trocar/importar perfil com sucesso para que o Codex releia o auth.json sem recarregar toda a janela do VS Code",
+  "configuration.reloadWindowAfterProfileSwitch.description": "Reiniciar o extension host do VS Code apos trocar/importar perfil com sucesso; se nao estiver disponivel, recarregar a janela para que a extensao Codex releia o auth.json",
   "configuration.statusBarClickBehavior.description": "Comportamento ao clicar no item de perfil da barra de status",
   "configuration.statusBarClickBehavior.cycle": "Alternar em ciclo por todos os perfis salvos",
   "configuration.statusBarClickBehavior.toggleLast": "Alternar entre o perfil atual e o anterior",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -13,7 +13,7 @@
   "command.profile.addFromFile.title": "Codex Switch: Importar de arquivo",
   "command.profile.rename.title": "Codex Switch: Renomear perfil",
   "command.profile.delete.title": "Codex Switch: Excluir perfil",
-  "configuration.reloadWindowAfterProfileSwitch.description": "Recarregar a janela do VS Code apos trocar/importar perfil com sucesso para que a extensao Codex releia o auth.json",
+  "configuration.reloadWindowAfterProfileSwitch.description": "Reiniciar o host de extensoes apos trocar/importar perfil com sucesso para que o Codex releia o auth.json sem recarregar toda a janela do VS Code",
   "configuration.statusBarClickBehavior.description": "Comportamento ao clicar no item de perfil da barra de status",
   "configuration.statusBarClickBehavior.cycle": "Alternar em ciclo por todos os perfis salvos",
   "configuration.statusBarClickBehavior.toggleLast": "Alternar entre o perfil atual e o anterior",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,9 @@ export function registerCommands(
   onAuthChanged: () => Promise<void>,
 ) {
   type StatusBarClickBehavior = 'cycle' | 'toggleLast'
+  const codexExtensionId = 'openai.chatgpt'
+  const reloadWindowCommand = 'workbench.action.reloadWindow'
+  const restartExtensionHostCommand = 'workbench.action.restartExtensionHost'
 
   const maybeReloadWindowAfterProfileSwitch = async () => {
     const reloadAfterSwitch = vscode.workspace
@@ -26,7 +29,15 @@ export function registerCommands(
     if (!reloadAfterSwitch) {
       return
     }
-    await vscode.commands.executeCommand('workbench.action.reloadWindow')
+    if (!vscode.extensions.getExtension(codexExtensionId)) {
+      return
+    }
+
+    try {
+      await vscode.commands.executeCommand(restartExtensionHostCommand)
+    } catch {
+      await vscode.commands.executeCommand(reloadWindowCommand)
+    }
   }
 
   const getLoginCommandText = (): string =>

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,26 +18,29 @@ export function registerCommands(
   onAuthChanged: () => Promise<void>,
 ) {
   type StatusBarClickBehavior = 'cycle' | 'toggleLast'
-  const codexExtensionId = 'openai.chatgpt'
-  const reloadWindowCommand = 'workbench.action.reloadWindow'
-  const restartExtensionHostCommand = 'workbench.action.restartExtensionHost'
+  const restartExtensionHostCommandId =
+    'workbench.action.restartExtensionHost'
+  const reloadWindowCommandId = 'workbench.action.reloadWindow'
 
-  const maybeReloadWindowAfterProfileSwitch = async () => {
+  const maybeRestartAfterProfileSwitch = async () => {
     const reloadAfterSwitch = vscode.workspace
       .getConfiguration('codexSwitch')
       .get<boolean>('reloadWindowAfterProfileSwitch', false)
     if (!reloadAfterSwitch) {
       return
     }
-    if (!vscode.extensions.getExtension(codexExtensionId)) {
-      return
+
+    const commandIds = await vscode.commands.getCommands(true)
+    if (commandIds.includes(restartExtensionHostCommandId)) {
+      try {
+        await vscode.commands.executeCommand(restartExtensionHostCommandId)
+        return
+      } catch {
+        // Fall back to full window reload on older or restricted hosts.
+      }
     }
 
-    try {
-      await vscode.commands.executeCommand(restartExtensionHostCommand)
-    } catch {
-      await vscode.commands.executeCommand(reloadWindowCommand)
-    }
+    await vscode.commands.executeCommand(reloadWindowCommandId)
   }
 
   const getLoginCommandText = (): string =>
@@ -125,7 +128,7 @@ export function registerCommands(
         return
       }
       await onAuthChanged()
-      await maybeReloadWindowAfterProfileSwitch()
+      await maybeRestartAfterProfileSwitch()
     },
   )
 
@@ -143,7 +146,7 @@ export function registerCommands(
       }
 
       await onAuthChanged()
-      await maybeReloadWindowAfterProfileSwitch()
+      await maybeRestartAfterProfileSwitch()
     },
   )
 
@@ -158,7 +161,7 @@ export function registerCommands(
           return
         }
         await onAuthChanged()
-        await maybeReloadWindowAfterProfileSwitch()
+        await maybeRestartAfterProfileSwitch()
         return
       }
 
@@ -178,7 +181,7 @@ export function registerCommands(
       }
 
       await onAuthChanged()
-      await maybeReloadWindowAfterProfileSwitch()
+      await maybeRestartAfterProfileSwitch()
     },
   )
 
@@ -217,7 +220,7 @@ export function registerCommands(
         await profileManager.replaceProfileAuth(existing.id, authData)
         await profileManager.setActiveProfileId(existing.id)
         await onAuthChanged()
-        await maybeReloadWindowAfterProfileSwitch()
+        await maybeRestartAfterProfileSwitch()
         return
       }
 
@@ -239,7 +242,7 @@ export function registerCommands(
       const profile = await profileManager.createProfile(name, authData)
       await profileManager.setActiveProfileId(profile.id)
       await onAuthChanged()
-      await maybeReloadWindowAfterProfileSwitch()
+      await maybeRestartAfterProfileSwitch()
     },
   )
 
@@ -388,7 +391,7 @@ export function registerCommands(
         await profileManager.replaceProfileAuth(existing.id, authData)
         await profileManager.setActiveProfileId(existing.id)
         await onAuthChanged()
-        await maybeReloadWindowAfterProfileSwitch()
+        await maybeRestartAfterProfileSwitch()
         return
       }
 
@@ -408,7 +411,7 @@ export function registerCommands(
       const profile = await profileManager.createProfile(name, authData)
       await profileManager.setActiveProfileId(profile.id)
       await onAuthChanged()
-      await maybeReloadWindowAfterProfileSwitch()
+      await maybeRestartAfterProfileSwitch()
     },
   )
 
@@ -463,7 +466,7 @@ export function registerCommands(
       try {
         const result = await profileManager.importProfilesFromTransfer(payload)
         await onAuthChanged()
-        await maybeReloadWindowAfterProfileSwitch()
+        await maybeRestartAfterProfileSwitch()
         vscode.window.showInformationMessage(
           vscode.l10n.t(
             'Import completed: created {0}, updated {1}, skipped {2}.',


### PR DESCRIPTION
## Summary
Restart only the extension host after a successful profile switch or import when `codexSwitch.reloadWindowAfterProfileSwitch` is enabled.

## Changes
- prefer `workbench.action.restartExtensionHost` when that command is available in the current VS Code host
- fall back to `workbench.action.reloadWindow` when the restart command is unavailable or fails
- stop depending on a specific chat extension identifier to decide whether restart is supported
- update the setting description and README to reflect the lighter refresh behavior

## Validation
- `npm run compile`
- `npm run lint:ts`