### PR TITLE
Fix Chat auth preservation and login preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,25 @@ and keep profile state consistent across clients.
 1. Sign in with Codex CLI in the runtime you actually use.
    If you use WSL from Windows and enabled
    `chatgpt.runCodexInWindowsSubsystemForLinux`, run `wsl codex login`.
-1. Run `Codex Switch: Manage Profiles`.
-1. Import from current `auth.json` or from a selected JSON file.
-1. Switch profiles from the status bar, tooltip links, or the manage command.
+   Alternatively, sign in from the Chat/Codex UI.
+2. Run `Codex Switch: Manage Profiles`.
+3. Import from current `auth.json` or from a selected JSON file.
+4. Switch profiles from the status bar, tooltip links, or the manage command.
+
+## Adding Another Chat Login
+
+Use `Codex Switch: Prepare for New Login (Chat)` before signing in
+with another Chat/Codex account.
+
+The command preserves the current live auth into a matching saved profile
+when possible, removes the local `auth.json`, clears the active profile,
+and reloads so Chat can show the login screen again.
+If the current live account is not saved as a profile,
+Codex Switch asks you to choose `Cancel`,
+`Save Profile and Continue`, or `Continue without saving`.
+
+Do not use logout as the way to add the next account.
+Logout can invalidate the current token session.
 
 ## How Switching Works
 
@@ -38,6 +54,10 @@ Click behavior is configurable:
 After a successful switch,
 Codex Switch writes the chosen auth data into the active auth file,
 so CLI and extension state stay aligned.
+
+Before switching away from an unsaved live account,
+Codex Switch asks whether to cancel, save the profile and continue,
+or continue without saving.
 
 ## Auth File Resolution
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
         "title": "%command.profile.addFromCodexAuthFile.title%"
       },
       {
+        "command": "codex-switch.profile.prepareForNewLoginChat",
+        "title": "%command.profile.prepareForNewLoginChat.title%"
+      },
+      {
         "command": "codex-switch.profile.addFromFile",
         "title": "%command.profile.addFromFile.title%"
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
   "command.profile.switch.title": "Codex Switch: Switch Profile",
   "command.profile.toggleLast.title": "Codex Switch: Cycle Profiles",
   "command.profile.addFromCodexAuthFile.title": "Codex Switch: Add From Current auth.json",
+  "command.profile.prepareForNewLoginChat.title": "Codex Switch: Prepare for New Login (Chat)",
   "command.profile.addFromFile.title": "Codex Switch: Import From File",
   "command.profile.exportSettings.title": "Codex Switch: Export Profiles",
   "command.profile.importSettings.title": "Codex Switch: Import Profiles",

--- a/src/auth/profile-manager.ts
+++ b/src/auth/profile-manager.ts
@@ -70,6 +70,20 @@ interface ParsedImportEntry {
   authData: AuthData
 }
 
+interface CanonicalTokenBundle {
+  idToken: string
+  accessToken: string
+  refreshToken: string
+}
+
+interface LiveAuthPreservationResult {
+  status: 'noLiveAuth' | 'saved' | 'unsaved'
+}
+
+interface PrepareForNewLoginChatResult {
+  removedAuthFile: boolean
+}
+
 function asObject(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null
@@ -344,36 +358,80 @@ export class ProfileManager {
     )
   }
 
-  private hasCanonicalAuthJson(authData: AuthData | null): boolean {
-    return (
-      !!authData && !!authData.authJson && typeof authData.authJson === 'object'
-    )
+  private getCanonicalTokenBundle(
+    authData: AuthData,
+  ): CanonicalTokenBundle | undefined {
+    const authJson = asObject(authData.authJson)
+    if (!authJson) {
+      return undefined
+    }
+
+    const tokens = asObject(authJson.tokens)
+    if (!tokens) {
+      return undefined
+    }
+
+    const idToken = this.asNonEmptyString(tokens.id_token)
+    const accessToken = this.asNonEmptyString(tokens.access_token)
+    const refreshToken = this.asNonEmptyString(tokens.refresh_token)
+
+    if (!idToken || !accessToken || !refreshToken) {
+      return undefined
+    }
+
+    return {
+      idToken,
+      accessToken,
+      refreshToken,
+    }
   }
 
   private shouldReplaceStoredProfileAuthWithLive(
     storedAuth: AuthData | null,
     liveAuth: AuthData,
   ): boolean {
-    if (!this.hasCanonicalAuthJson(liveAuth)) {
+    const liveTokens = this.getCanonicalTokenBundle(liveAuth)
+    if (!liveTokens) {
       return false
     }
+
     if (!storedAuth) {
       return true
     }
-    if (!this.hasCanonicalAuthJson(storedAuth)) {
+
+    const storedTokens = this.getCanonicalTokenBundle(storedAuth)
+    if (!storedTokens) {
       return true
     }
 
     const storedRefresh = this.getAuthLastRefresh(storedAuth)
     const liveRefresh = this.getAuthLastRefresh(liveAuth)
 
-    if (storedRefresh === undefined) {
-      return true
-    }
-    if (liveRefresh === undefined) {
+    if (
+      storedRefresh !== undefined &&
+      liveRefresh !== undefined &&
+      liveRefresh < storedRefresh
+    ) {
       return false
     }
-    return liveRefresh > storedRefresh
+
+    if (storedRefresh !== undefined && liveRefresh === undefined) {
+      return false
+    }
+
+    if (
+      storedTokens.idToken !== liveTokens.idToken ||
+      storedTokens.accessToken !== liveTokens.accessToken ||
+      storedTokens.refreshToken !== liveTokens.refreshToken
+    ) {
+      return true
+    }
+
+    if (storedRefresh === undefined && liveRefresh !== undefined) {
+      return true
+    }
+
+    return false
   }
 
   private async maybeReplaceProfileAuthWithLive(
@@ -1016,6 +1074,27 @@ export class ProfileManager {
     }
   }
 
+  async preserveLiveAuthForMatchingProfile(): Promise<LiveAuthPreservationResult> {
+    const liveAuth = await this.loadLiveCodexAuthData()
+    if (!liveAuth) {
+      return { status: 'noLiveAuth' }
+    }
+
+    const activeId = await this.getActiveProfileId()
+    const matchingProfile = await this.findProfileByPreservationIdentity(
+      liveAuth,
+      activeId,
+    )
+
+    if (!matchingProfile) {
+      return { status: 'unsaved' }
+    }
+
+    await this.maybeReplaceProfileAuthWithLive(matchingProfile, liveAuth)
+
+    return { status: 'saved' }
+  }
+
   private async captureLiveAuthForMatchingProfile(
     authPath: string,
   ): Promise<void> {
@@ -1287,6 +1366,26 @@ export class ProfileManager {
     const bucket = this.getStateBucket()
     await bucket.update(ACTIVE_PROFILE_KEY, profileId)
     await bucket.update(OLD_ACTIVE_PROFILE_KEY, undefined)
+  }
+
+  async prepareForNewLoginChat(): Promise<PrepareForNewLoginChatResult> {
+    const authPath = getDefaultCodexAuthPath()
+
+    await this.setActiveProfileIdInState(undefined)
+    this.lastSyncedProfileId = undefined
+    this.lastSyncedAuthHash = undefined
+
+    if (!fs.existsSync(authPath)) {
+      return {
+        removedAuthFile: false,
+      }
+    }
+
+    fs.unlinkSync(authPath)
+
+    return {
+      removedAuthFile: true,
+    }
   }
 
   async setActiveProfileId(profileId: string | undefined): Promise<boolean> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -42,6 +42,21 @@ export function registerCommands(
     await vscode.commands.executeCommand(reloadWindowCommandId)
   }
 
+  const reloadAfterAuthReset = async (): Promise<void> => {
+    const commandIds = await vscode.commands.getCommands(true)
+
+    if (commandIds.includes(restartExtensionHostCommandId)) {
+      try {
+        await vscode.commands.executeCommand(restartExtensionHostCommandId)
+        return
+      } catch {
+        // Fall back to full window reload.
+      }
+    }
+
+    await vscode.commands.executeCommand(reloadWindowCommandId)
+  }
+
   const getLoginCommandText = (): string =>
     shouldUseWslAuthPath() ? 'wsl codex login' : 'codex login'
 
@@ -63,6 +78,106 @@ export function registerCommands(
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
     const baseDir = workspacePath || os.homedir()
     return vscode.Uri.file(path.join(baseDir, 'codex-switch-profiles.json'))
+  }
+
+  const addCurrentAuthJsonAsProfile = async (
+    restartAfterImport: boolean,
+  ): Promise<boolean> => {
+    const authPath = getDefaultCodexAuthPath()
+    const loginCommandText = getLoginCommandText()
+    const authData = await loadAuthDataFromFile(authPath)
+    if (!authData) {
+      vscode.window.showErrorMessage(
+        vscode.l10n.t(
+          'Could not read auth from {0}. Run "{1}" first.',
+          authPath,
+          loginCommandText,
+        ),
+      )
+      return false
+    }
+
+    const existing = await profileManager.findDuplicateProfile(authData)
+    if (existing) {
+      const replaceLabel = vscode.l10n.t('Replace')
+      const pick = await vscode.window.showWarningMessage(
+        vscode.l10n.t(
+          'This account is already saved as profile "{0}". Replace it?',
+          existing.name,
+        ),
+        { modal: true },
+        replaceLabel,
+      )
+      if (pick !== replaceLabel) {
+        return false
+      }
+
+      await profileManager.replaceProfileAuth(existing.id, authData)
+      await profileManager.setActiveProfileId(existing.id)
+      await onAuthChanged()
+      if (restartAfterImport) {
+        await maybeRestartAfterProfileSwitch()
+      }
+      return true
+    }
+
+    const defaultName =
+      authData.email && authData.email !== 'Unknown'
+        ? authData.email.split('@')[0]
+        : 'profile'
+
+    const name = await vscode.window.showInputBox({
+      prompt: vscode.l10n.t('Profile name (for example "work" or "personal")'),
+      value: defaultName,
+    })
+    if (!name) {
+      return false
+    }
+    if (!name.trim()) {
+      return false
+    }
+
+    const profile = await profileManager.createProfile(name, authData)
+    await profileManager.setActiveProfileId(profile.id)
+    await onAuthChanged()
+    if (restartAfterImport) {
+      await maybeRestartAfterProfileSwitch()
+    }
+    return true
+  }
+
+  const ensureLiveAuthIsSavedBeforeReplacing = async (
+    operationName: string,
+  ): Promise<boolean> => {
+    const result = await profileManager.preserveLiveAuthForMatchingProfile()
+
+    if (result.status !== 'unsaved') {
+      return true
+    }
+
+    const saveAndContinueLabel = vscode.l10n.t('Save Profile and Continue')
+    const continueWithoutSavingLabel = vscode.l10n.t('Continue without saving')
+
+    const pick = await vscode.window.showWarningMessage(
+      vscode.l10n.t(
+        'The current Codex account is not saved in Codex Switch. If you continue to {0}, this local login will be removed or overwritten and you will need to sign in again to recover it.',
+        operationName,
+      ),
+      { modal: true },
+      saveAndContinueLabel,
+      continueWithoutSavingLabel,
+    )
+
+    if (!pick) {
+      return false
+    }
+    if (pick === continueWithoutSavingLabel) {
+      return true
+    }
+    if (pick === saveAndContinueLabel) {
+      return addCurrentAuthJsonAsProfile(false)
+    }
+    return false
   }
 
   // Login command
@@ -129,6 +244,12 @@ export function registerCommands(
       if (!pick) {
         return
       }
+      const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('switch profiles'),
+      )
+      if (!canReplaceLiveAuth) {
+        return
+      }
       const ok = await profileManager.setActiveProfileId(pick.profileId)
       if (!ok) {
         return
@@ -143,6 +264,13 @@ export function registerCommands(
     async (profileId?: string) => {
       if (!profileId) {
         await vscode.commands.executeCommand('codex-switch.profile.switch')
+        return
+      }
+
+      const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('switch profiles'),
+      )
+      if (!canReplaceLiveAuth) {
         return
       }
 
@@ -166,6 +294,13 @@ export function registerCommands(
       }
 
       if (behavior === 'toggleLast') {
+        const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+          vscode.l10n.t('switch profiles'),
+        )
+        if (!canReplaceLiveAuth) {
+          return
+        }
+
         const newId = await profileManager.toggleLastProfileId()
         if (!newId) {
           await vscode.commands.executeCommand('codex-switch.profile.switch')
@@ -186,6 +321,12 @@ export function registerCommands(
       const currentIndex = profiles.findIndex((p) => p.id === activeId)
       const nextIndex =
         currentIndex === -1 ? 0 : (currentIndex + 1) % profiles.length
+      const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('switch profiles'),
+      )
+      if (!canReplaceLiveAuth) {
+        return
+      }
       const ok = await profileManager.setActiveProfileId(profiles[nextIndex].id)
       if (!ok) {
         return
@@ -198,68 +339,50 @@ export function registerCommands(
 
   const addFromCodexAuthFileCommand = vscode.commands.registerCommand(
     'codex-switch.profile.addFromCodexAuthFile',
+    async (): Promise<boolean> => addCurrentAuthJsonAsProfile(true),
+  )
+
+  const prepareForNewLoginChatCommand = vscode.commands.registerCommand(
+    'codex-switch.profile.prepareForNewLoginChat',
     async () => {
-      const authPath = getDefaultCodexAuthPath()
-      const loginCommandText = getLoginCommandText()
-      const authData = await loadAuthDataFromFile(authPath)
-      if (!authData) {
-        vscode.window.showErrorMessage(
-          vscode.l10n.t(
-            'Could not read auth from {0}. Run "{1}" first.',
-            authPath,
-            loginCommandText,
-          ),
-        )
+      const ok = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('prepare for a new login'),
+      )
+      if (!ok) {
         return
       }
 
-      const existing = await profileManager.findDuplicateProfile(authData)
-      if (existing) {
-        const replaceLabel = vscode.l10n.t('Replace')
-        const pick = await vscode.window.showWarningMessage(
-          vscode.l10n.t(
-            'This account is already saved as profile "{0}". Replace it?',
-            existing.name,
-          ),
-          { modal: true },
-          replaceLabel,
-        )
-        if (pick !== replaceLabel) {
-          return
-        }
-
-        await profileManager.replaceProfileAuth(existing.id, authData)
-        await profileManager.setActiveProfileId(existing.id)
-        await onAuthChanged()
-        await maybeRestartAfterProfileSwitch()
-        return
-      }
-
-      const defaultName =
-        authData.email && authData.email !== 'Unknown'
-          ? authData.email.split('@')[0]
-          : 'profile'
-
-      const name = await vscode.window.showInputBox({
-        prompt: vscode.l10n.t(
-          'Profile name (for example "work" or "personal")',
-        ),
-        value: defaultName,
-      })
-      if (!name) {
-        return
-      }
-
-      const profile = await profileManager.createProfile(name, authData)
-      await profileManager.setActiveProfileId(profile.id)
+      const result = await profileManager.prepareForNewLoginChat()
       await onAuthChanged()
-      await maybeRestartAfterProfileSwitch()
+
+      if (result.removedAuthFile) {
+        vscode.window.showInformationMessage(
+          vscode.l10n.t(
+            'Prepared for a new Codex login. The current auth.json was removed locally and the window will reload so Chat can show the login flow.',
+          ),
+        )
+      } else {
+        vscode.window.showInformationMessage(
+          vscode.l10n.t(
+            'Prepared for a new Codex login. No current auth.json was found and the window will reload so Chat can show the login flow.',
+          ),
+        )
+      }
+
+      await reloadAfterAuthReset()
     },
   )
 
   const loginViaCliCommand = vscode.commands.registerCommand(
     'codex-switch.profile.login',
     async () => {
+      const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('start a new login'),
+      )
+      if (!canReplaceLiveAuth) {
+        return
+      }
+
       const authPath = getDefaultCodexAuthPath()
       const loginSequence = `${getLoginCommandText()}\n`
 
@@ -390,6 +513,13 @@ export function registerCommands(
         return
       }
 
+      const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+        vscode.l10n.t('import an auth file'),
+      )
+      if (!canReplaceLiveAuth) {
+        return
+      }
+
       const existing = await profileManager.findDuplicateProfile(authData)
       if (existing) {
         const replaceLabel = vscode.l10n.t('Replace')
@@ -481,6 +611,13 @@ export function registerCommands(
       }
 
       try {
+        const canReplaceLiveAuth = await ensureLiveAuthIsSavedBeforeReplacing(
+          vscode.l10n.t('import profiles'),
+        )
+        if (!canReplaceLiveAuth) {
+          return
+        }
+
         const result = await profileManager.importProfilesFromTransfer(payload)
         await onAuthChanged()
         await maybeRestartAfterProfileSwitch()
@@ -582,6 +719,13 @@ export function registerCommands(
       const action = await vscode.window.showQuickPick(
         [
           {
+            label: vscode.l10n.t('Prepare for New Login (Chat)'),
+            description: vscode.l10n.t(
+              'Save current profile if possible, remove local auth.json, and reload Chat login',
+            ),
+            command: 'codex-switch.profile.prepareForNewLoginChat',
+          },
+          {
             label: vscode.l10n.t('Login via Codex CLI...'),
             command: 'codex-switch.profile.login',
           },
@@ -640,6 +784,7 @@ export function registerCommands(
   context.subscriptions.push(toggleLastProfileCommand)
   context.subscriptions.push(manageProfilesCommand)
   context.subscriptions.push(addFromCodexAuthFileCommand)
+  context.subscriptions.push(prepareForNewLoginChatCommand)
   context.subscriptions.push(addFromFileCommand)
   context.subscriptions.push(exportSettingsCommand)
   context.subscriptions.push(importSettingsCommand)


### PR DESCRIPTION
## Summary
This PR fixes a stale-auth preservation edge case and adds a safer Chat/Codex login preparation flow for multi-account usage.

### Bugfix
Codex can refresh `auth.json` while a profile is active. Previously, a saved profile could remain stale if the live token bundle changed but the saved profile was not updated before switching/removing the active auth file.

This PR fixes that by:
- preserving refreshed live auth into the matching saved profile before auth replacement/removal,
- requiring a complete canonical token bundle before saving live auth back into a profile,
- preventing partial or malformed live auth from overwriting saved profile data.

### New Chat login preparation flow
Adds `Codex Switch: Prepare for New Login (Chat)`.

This command prepares the Chat/Codex UI for another account login without calling logout:
- preserves the current live auth into a matching saved profile when possible,
- removes the local `auth.json`,
- clears active profile state,
- reloads so Chat can show the login screen again.

This avoids using logout as part of multi-account enrollment, which can revoke the token session that was just saved.

### Unsaved-auth protection
The extension now warns before destructive/replacement flows when the current live auth is not saved as a profile.

Covered paths:
- Prepare for New Login (Chat)
- Switch Profile
- Activate Profile
- Cycle / Toggle Profile
- Login via Codex CLI
- Import From File
- Import Profiles

The warning actions are:
- Save Profile and Continue
- Continue without saving
- native Cancel

## Documentation
README now documents the Chat/Codex UI login flow as an alternative to the existing CLI login flow and explains how to safely add another Chat login.

## Testing
- `npm run compile`
- `npm run lint:ts`
- `npm run format:check`
- `npm run lint:md`
- Packaged VSIX successfully
- Runtime-tested locally