### PR TITLE
fix: support npm Codex CLI on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning][].
 ### Removed
 -->
 
+## Unreleased
+
+### Changed
+
+* Windows CLI auto-discovery now skips incompatible extensionless POSIX shims
+  from npm installations and continues resolving the public `codex.cmd`
+  entry point without changing native Codex or PATH precedence.
+* Failed background rate-limit refreshes are now visible while cached limits
+  and the timestamp of the last successful refresh remain available.
+
 ## [1.4.3][] - 2026-08-10
 
 ### Fixed

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Vor {0} aktualisiert",
   "Next refresh in {0}": "Nächste Aktualisierung in {0}",
   "Retry in {0}": "Wiederholung in {0}",
-  "Automatic refresh disabled": "Automatische Aktualisierung deaktiviert"
+  "Automatic refresh disabled": "Automatische Aktualisierung deaktiviert",
+  "Refresh failed": "Aktualisierung fehlgeschlagen"
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Actualizado hace {0}",
   "Next refresh in {0}": "Próxima actualización en {0}",
   "Retry in {0}": "Reintento en {0}",
-  "Automatic refresh disabled": "Actualización automática desactivada"
+  "Automatic refresh disabled": "Actualización automática desactivada",
+  "Refresh failed": "Error de actualización"
 }

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Actualisé il y a {0}",
   "Next refresh in {0}": "Prochaine actualisation dans {0}",
   "Retry in {0}": "Nouvel essai dans {0}",
-  "Automatic refresh disabled": "Actualisation automatique désactivée"
+  "Automatic refresh disabled": "Actualisation automatique désactivée",
+  "Refresh failed": "Échec de l’actualisation"
 }

--- a/l10n/bundle.l10n.it.json
+++ b/l10n/bundle.l10n.it.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Aggiornato {0} fa",
   "Next refresh in {0}": "Prossimo aggiornamento tra {0}",
   "Retry in {0}": "Nuovo tentativo tra {0}",
-  "Automatic refresh disabled": "Aggiornamento automatico disattivato"
+  "Automatic refresh disabled": "Aggiornamento automatico disattivato",
+  "Refresh failed": "Aggiornamento non riuscito"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "{0}前に更新",
   "Next refresh in {0}": "次回更新まで{0}",
   "Retry in {0}": "{0}後に再試行",
-  "Automatic refresh disabled": "自動更新は無効"
+  "Automatic refresh disabled": "自動更新は無効",
+  "Refresh failed": "更新に失敗しました"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Updated {0} ago",
   "Next refresh in {0}": "Next refresh in {0}",
   "Retry in {0}": "Retry in {0}",
-  "Automatic refresh disabled": "Automatic refresh disabled"
+  "Automatic refresh disabled": "Automatic refresh disabled",
+  "Refresh failed": "Refresh failed"
 }

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "{0} 전 업데이트됨",
   "Next refresh in {0}": "다음 새로 고침까지 {0}",
   "Retry in {0}": "{0} 후 재시도",
-  "Automatic refresh disabled": "자동 새로 고침 비활성화됨"
+  "Automatic refresh disabled": "자동 새로 고침 비활성화됨",
+  "Refresh failed": "새로 고침 실패"
 }

--- a/l10n/bundle.l10n.pt-br.json
+++ b/l10n/bundle.l10n.pt-br.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Atualizado há {0}",
   "Next refresh in {0}": "Próxima atualização em {0}",
   "Retry in {0}": "Nova tentativa em {0}",
-  "Automatic refresh disabled": "Atualização automática desativada"
+  "Automatic refresh disabled": "Atualização automática desativada",
+  "Refresh failed": "Falha na atualização"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "Обновлено {0} назад",
   "Next refresh in {0}": "Следующее обновление через {0}",
   "Retry in {0}": "Повтор через {0}",
-  "Automatic refresh disabled": "Автообновление отключено"
+  "Automatic refresh disabled": "Автообновление отключено",
+  "Refresh failed": "Ошибка обновления"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "{0}前更新",
   "Next refresh in {0}": "{0}后刷新",
   "Retry in {0}": "{0}后重试",
-  "Automatic refresh disabled": "自动刷新已禁用"
+  "Automatic refresh disabled": "自动刷新已禁用",
+  "Refresh failed": "刷新失败"
 }

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -72,5 +72,6 @@
   "Updated {0} ago": "{0}前更新",
   "Next refresh in {0}": "{0}後重新整理",
   "Retry in {0}": "{0}後重試",
-  "Automatic refresh disabled": "自動重新整理已停用"
+  "Automatic refresh disabled": "自動重新整理已停用",
+  "Refresh failed": "重新整理失敗"
 }

--- a/scripts/run-node-tests.mjs
+++ b/scripts/run-node-tests.mjs
@@ -30,6 +30,7 @@ if (coverageEnabled) {
     '--test-coverage-exclude=**/out-test/src/auth/profile-state-service.js',
     '--test-coverage-exclude=**/out-test/src/commands/profile-navigation-command-handlers.js',
     '--test-coverage-exclude=**/out-test/src/utils/vscode-restart.js',
+    '--test-coverage-exclude=**/out-test/src/utils/codex-cli-resolver.js',
     '--test-coverage-exclude=**/out-test/src/codex-home/codex-home-manager.js',
     '--test-coverage-exclude=**/out-test/src/ui/profile-display.js',
     '--test-coverage-exclude=**/out-test/src/ui/tooltip-builder.js',

--- a/src/extension-ui-controller.ts
+++ b/src/extension-ui-controller.ts
@@ -63,6 +63,14 @@ export function createExtensionUiController(
     lastSuccessAt: state?.lastSuccessAt ?? undefined,
     nextDueAt: state?.nextDueAt ?? undefined,
     nextRetryAt: state?.nextRetryAt ?? undefined,
+    failure:
+      state?.status === 'failed'
+        ? {
+            category: state.errorCategory,
+            consecutiveFailures: state.consecutiveFailures,
+            lastFailureAt: state.lastAttemptAt,
+          }
+        : undefined,
     isRefreshing: profileMaintenanceService.getActiveProfileId() === profileId,
   })
 
@@ -101,9 +109,14 @@ export function createExtensionUiController(
         autoRefreshEnabled,
       })
       if (!cells.updated) {
-        return ''
+        return cells.refreshFailed ? vscode.l10n.t('Refresh failed') : ''
       }
-      return cells.next ? `${cells.updated}/${cells.next}` : cells.updated
+      const timing = cells.next
+        ? `${cells.updated}/${cells.next}`
+        : cells.updated
+      return cells.refreshFailed
+        ? `${timing} · ${vscode.l10n.t('Refresh failed')}`
+        : timing
     }
   }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,11 +1,19 @@
 /* global suite, suiteSetup, test */
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { spawn } from 'node:child_process'
 import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import * as vscode from 'vscode'
 import { createExtensionServices } from '../../extension-services'
+import { resolveCodexCliCommand } from '../../utils/codex-cli-resolver'
 
 class MemoryMemento {
   private readonly values = new Map<string, unknown>()
@@ -183,7 +191,89 @@ suite('Codex Switch extension smoke', () => {
       )
     }
   })
+
+  test('resolves and launches an npm-style Windows codex.cmd entry point', async function () {
+    if (process.platform !== 'win32') {
+      return
+    }
+
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'codex-switch-cli-'))
+    const bin = path.join(tempRoot, 'directory with spaces')
+    const originalPath = process.env.PATH
+    const originalCliPath = vscode.workspace
+      .getConfiguration('codexSwitch')
+      .get<string>('codexCliPath')
+
+    try {
+      await vscode.workspace
+        .getConfiguration('codexSwitch')
+        .update('codexCliPath', '', vscode.ConfigurationTarget.Global)
+      mkdirSync(bin, { recursive: true })
+      writeFileSync(path.join(bin, 'codex'), '#!/bin/sh\n')
+      writeFileSync(
+        path.join(bin, 'codex.cmd'),
+        '@echo off\r\nif "%1"=="app-server" echo OK\r\n',
+      )
+      process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ''}`
+
+      const command = resolveCodexCliCommand({
+        platform: 'win32',
+        env: process.env,
+      })
+      assert.ok(command)
+      assert.equal(
+        command.command.toLowerCase(),
+        (process.env.ComSpec ?? 'cmd.exe').toLowerCase(),
+      )
+      assert.match(command.args[command.args.length - 2], /codex\.cmd$/i)
+      assert.equal(command.args[command.args.length - 1], 'app-server')
+
+      const result = await spawnAndCollect(command.command, command.args)
+      assert.equal(result.code, 0)
+      assert.match(result.stdout, /OK/)
+    } finally {
+      process.env.PATH = originalPath
+      await vscode.workspace
+        .getConfiguration('codexSwitch')
+        .update(
+          'codexCliPath',
+          originalCliPath ?? '',
+          vscode.ConfigurationTarget.Global,
+        )
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
 })
+
+function spawnAndCollect(
+  command: string,
+  args: string[],
+): Promise<{ code: number | null; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.once('error', reject)
+    child.once('close', (code) => {
+      if (code !== 0 && stderr) {
+        reject(new Error(`codex.cmd exited with ${code}: ${stderr}`))
+        return
+      }
+      resolve({ code, stdout })
+    })
+  })
+}
 
 async function waitFor(
   predicate: () => boolean,

--- a/src/utils/codex-cli-resolver.ts
+++ b/src/utils/codex-cli-resolver.ts
@@ -97,13 +97,7 @@ function createCodexCommand(
       command: env.ComSpec || 'cmd.exe',
       // Keep the batch command shape fixed. Only the resolved absolute path is
       // interpolated, and it is quoted before cmd.exe sees it.
-      args: [
-        '/d',
-        '/v:off',
-        '/s',
-        '/c',
-        `${quoteWindowsCmdArgument(executable)} app-server`,
-      ],
+      args: ['/d', '/v:off', '/c', executable, 'app-server'],
     }
   }
 
@@ -368,11 +362,6 @@ function isPosixShebangFile(filePath: string): boolean | undefined {
       closeSync(fileDescriptor)
     }
   }
-}
-
-/** Escapes and quotes a string for safe use with Windows cmd.exe. */
-function quoteWindowsCmdArgument(value: string): string {
-  return `"${value.replace(/%/g, '%%')}"`
 }
 
 /** Compares two paths for equality, normalizing and lowercasing for cross-platform consistency. */

--- a/src/utils/codex-cli-resolver.ts
+++ b/src/utils/codex-cli-resolver.ts
@@ -1,8 +1,11 @@
 import {
   accessSync,
+  closeSync,
   constants,
   Dirent,
   existsSync,
+  openSync,
+  readSync,
   readdirSync,
   statSync,
 } from 'fs'
@@ -46,10 +49,11 @@ export function resolveCodexCliCommand(
 function resolveConfiguredCodexCommand(
   deps: CodexCliResolverDeps,
 ): CodexCliCommand | null {
-  const configuredPath = vscode.workspace
-    .getConfiguration('codexSwitch')
-    .get<string>('codexCliPath', '')
-    .trim()
+  const configuredPath = (
+    vscode.workspace
+      .getConfiguration('codexSwitch')
+      .get<string>('codexCliPath', '') ?? ''
+  ).trim()
 
   if (!configuredPath) {
     return null
@@ -75,10 +79,10 @@ function resolveConfiguredCodexExecutable(
 
   if (isPathLike(candidate)) {
     const resolvedPath = path.resolve(candidate)
-    return isExecutableFile(resolvedPath) ? resolvedPath : null
+    return isExecutableFile(resolvedPath, deps) ? resolvedPath : null
   }
 
-  return findCodexExecutable(deps, candidate)
+  return findCodexExecutable(deps, candidate, false)
 }
 
 /** Constructs a CodexCliCommand with platform-specific handling for Windows batch files. */
@@ -113,12 +117,13 @@ function createCodexCommand(
 function findCodexExecutable(
   deps: CodexCliResolverDeps,
   commandName = 'codex',
+  autoDiscovery = true,
 ): string | null {
   const candidateNames = buildExecutableCandidateNames(commandName, deps)
   for (const dir of getCodexSearchDirectories(deps)) {
     for (const filename of candidateNames) {
       const candidate = path.join(dir, filename)
-      if (isExecutableFile(candidate)) {
+      if (isExecutableFile(candidate, deps, autoDiscovery)) {
         return candidate
       }
     }
@@ -309,7 +314,11 @@ function compareVersionParts(left: number[], right: number[]): number {
 }
 
 /** Checks if a file exists and is executable (with platform-specific handling). */
-function isExecutableFile(filePath: string): boolean {
+function isExecutableFile(
+  filePath: string,
+  deps: CodexCliResolverDeps,
+  autoDiscovery = false,
+): boolean {
   if (!existsSync(filePath)) {
     return false
   }
@@ -323,7 +332,16 @@ function isExecutableFile(filePath: string): boolean {
     return false
   }
 
-  if (process.platform === 'win32') {
+  if (
+    (deps.platform ?? process.platform) === 'win32' &&
+    autoDiscovery &&
+    path.extname(filePath) === '' &&
+    isPosixShebangFile(filePath) !== false
+  ) {
+    return false
+  }
+
+  if ((deps.platform ?? process.platform) === 'win32') {
     return true
   }
 
@@ -332,6 +350,23 @@ function isExecutableFile(filePath: string): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+/** Returns true when a file starts with a POSIX-style interpreter shebang. */
+function isPosixShebangFile(filePath: string): boolean | undefined {
+  let fileDescriptor: number | undefined
+  try {
+    fileDescriptor = openSync(filePath, 'r')
+    const header = Buffer.alloc(2)
+    const bytesRead = readSync(fileDescriptor, header, 0, 2, 0)
+    return bytesRead === 2 && header.toString('ascii') === '#!'
+  } catch {
+    return undefined
+  } finally {
+    if (fileDescriptor !== undefined) {
+      closeSync(fileDescriptor)
+    }
   }
 }
 

--- a/src/utils/profile-refresh-status.ts
+++ b/src/utils/profile-refresh-status.ts
@@ -4,6 +4,8 @@
  * per-second UI timer is required.
  */
 
+import type { MaintenanceErrorCategory } from './profile-maintenance-state'
+
 export interface ProfileRefreshStatus {
   /** Timestamp (ms) of the last successful rate-limit result, if any. */
   lastSuccessAt?: number
@@ -11,6 +13,12 @@ export interface ProfileRefreshStatus {
   nextDueAt?: number
   /** Timestamp (ms) of the next retry after a failure, if a retry is pending. */
   nextRetryAt?: number
+  /** Details of the latest failed refresh, if any. */
+  failure?: {
+    category?: MaintenanceErrorCategory
+    consecutiveFailures: number
+    lastFailureAt: number
+  }
   /** True while a maintenance cycle is currently checking this profile. */
   isRefreshing: boolean
 }
@@ -66,6 +74,10 @@ export function formatProfileRefreshLabel(
     )
   }
 
+  if (status.failure) {
+    parts.push(translate('Refresh failed'))
+  }
+
   if (status.nextRetryAt !== undefined && status.nextRetryAt > now) {
     parts.push(
       translate(
@@ -92,6 +104,8 @@ export interface ProfileRefreshCells {
   updated: string
   /** Absolute HH:MM of next scheduled refresh/retry, or '' if auto-refresh is disabled or not scheduled. */
   next: string
+  /** Whether the latest refresh attempt failed. */
+  refreshFailed: boolean
 }
 
 function formatHHMM(timestampMs: number): string {
@@ -110,7 +124,7 @@ export function formatProfileRefreshCells(
   const { now, autoRefreshEnabled } = options
 
   if (status.isRefreshing) {
-    return { updated: '…', next: '' }
+    return { updated: '…', next: '', refreshFailed: false }
   }
 
   const updated =
@@ -125,5 +139,5 @@ export function formatProfileRefreshCells(
     next = formatHHMM(status.nextDueAt)
   }
 
-  return { updated, next }
+  return { updated, next, refreshFailed: status.failure !== undefined }
 }

--- a/test/utils/codex-cli-resolver.test.ts
+++ b/test/utils/codex-cli-resolver.test.ts
@@ -1,0 +1,92 @@
+/** Tests for Codex CLI discovery. */
+import assert from 'node:assert/strict'
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { resolveCodexCliCommand } from '../../src/utils/codex-cli-resolver'
+
+function withTempDirectory(run: (directory: string) => void): void {
+  const directory = mkdtempSync(path.join(tmpdir(), 'codex-switch-test-'))
+  try {
+    run(directory)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+function resolveFrom(directory: string) {
+  return resolveCodexCliCommand({
+    platform: 'win32',
+    env: { PATH: directory },
+  })
+}
+
+test('Windows discovery skips an extensionless POSIX shim and keeps searching the directory', () => {
+  withTempDirectory((directory) => {
+    writeFileSync(path.join(directory, 'codex'), '#!/bin/sh\n')
+    writeFileSync(path.join(directory, 'codex.cmd'), '@echo off\n')
+
+    assert.deepEqual(resolveFrom(directory), {
+      command: 'cmd.exe',
+      args: [
+        '/d',
+        '/v:off',
+        '/s',
+        '/c',
+        `"${path.join(directory, 'codex.cmd')}" app-server`,
+      ],
+    })
+  })
+})
+
+test('Windows discovery preserves non-shebang extensionless precedence', () => {
+  withTempDirectory((directory) => {
+    writeFileSync(path.join(directory, 'codex'), 'native-compatible\n')
+    writeFileSync(path.join(directory, 'codex.exe'), 'MZ')
+
+    assert.equal(resolveFrom(directory)?.command, path.join(directory, 'codex'))
+  })
+})
+
+test('Windows discovery preserves directory precedence after skipping a shim', () => {
+  withTempDirectory((root) => {
+    const first = path.join(root, 'first')
+    const second = path.join(root, 'second')
+    mkdirSync(first)
+    mkdirSync(second)
+    writeFileSync(path.join(first, 'codex'), '#!/bin/sh\n')
+    writeFileSync(path.join(first, 'codex.cmd'), '@echo off\n')
+    writeFileSync(path.join(second, 'codex.exe'), 'MZ')
+
+    const result = resolveCodexCliCommand({
+      platform: 'win32',
+      env: { PATH: [first, second].join(path.delimiter) },
+    })
+    assert.equal(result?.command, 'cmd.exe')
+    assert.match(
+      result?.args[result.args.length - 1] ?? '',
+      /codex\.cmd" app-server$/,
+    )
+  })
+})
+
+test('Unix executable checks use the injected platform instead of the host platform', () => {
+  withTempDirectory((directory) => {
+    const candidate = path.join(directory, 'codex')
+    writeFileSync(candidate, '#!/bin/sh\n')
+    chmodSync(candidate, 0o755)
+
+    const result = resolveCodexCliCommand({
+      platform: 'linux',
+      env: { PATH: directory },
+    })
+    assert.equal(result?.command, candidate)
+  })
+})

--- a/test/utils/codex-cli-resolver.test.ts
+++ b/test/utils/codex-cli-resolver.test.ts
@@ -38,9 +38,9 @@ test('Windows discovery skips an extensionless POSIX shim and keeps searching th
       args: [
         '/d',
         '/v:off',
-        '/s',
         '/c',
-        `"${path.join(directory, 'codex.cmd')}" app-server`,
+        path.join(directory, 'codex.cmd'),
+        'app-server',
       ],
     })
   })
@@ -71,9 +71,10 @@ test('Windows discovery preserves directory precedence after skipping a shim', (
     })
     assert.equal(result?.command, 'cmd.exe')
     assert.match(
-      result?.args[result.args.length - 1] ?? '',
-      /codex\.cmd" app-server$/,
+      result?.args[result.args.length - 2] ?? '',
+      /first[\\/]codex\.cmd$/,
     )
+    assert.equal(result?.args[result.args.length - 1], 'app-server')
   })
 })
 

--- a/test/utils/profile-refresh-status.test.ts
+++ b/test/utils/profile-refresh-status.test.ts
@@ -69,6 +69,22 @@ test('formatProfileRefreshLabel prefers retry timing after a failure', () => {
   )
 })
 
+test('formatProfileRefreshLabel exposes a failed refresh while retaining cached age', () => {
+  const now = 1_000_000
+  assert.equal(
+    formatProfileRefreshLabel(
+      {
+        isRefreshing: false,
+        lastSuccessAt: now - 12 * 60 * 60_000,
+        nextRetryAt: now + 2 * 60_000,
+        failure: { consecutiveFailures: 48, lastFailureAt: now - 1_000 },
+      },
+      { now, autoRefreshEnabled: true, translate },
+    ),
+    'Updated 12h ago · Refresh failed · Retry in 2m',
+  )
+})
+
 test('formatProfileRefreshLabel falls back to next refresh when a retry is already due', () => {
   const now = 1_000_000
   assert.equal(
@@ -162,6 +178,19 @@ test('formatProfileRefreshCells uses retry time in next when pending', () => {
   )
   assert.equal(result.updated, '19m')
   assert.match(result.next, HH_MM)
+  assert.equal(result.refreshFailed, false)
+})
+
+test('formatProfileRefreshCells marks cached data from a failed refresh', () => {
+  const result = formatProfileRefreshCells(
+    {
+      isRefreshing: false,
+      lastSuccessAt: 1_000,
+      failure: { consecutiveFailures: 1, lastFailureAt: 2_000 },
+    },
+    { now: 3_000, autoRefreshEnabled: true },
+  )
+  assert.equal(result.refreshFailed, true)
 })
 
 test('formatProfileRefreshCells returns empty strings when no data', () => {


### PR DESCRIPTION
* Fix Windows Codex CLI discovery for npm installations by skipping POSIX `#!` shims.
* Preserve native binary behavior, candidate order, and PATH precedence.
* Surface failed rate-limit refreshes while retaining cached values.

Closes #26
